### PR TITLE
Add fancy typehints on hover

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,3 +33,7 @@ doc = [
     'sphinx-autodoc-typehints',
 ]
 
+[tool.black]
+py36 = false
+exclude = '3.5'
+

--- a/scanpydoc/elegant_typehints.py
+++ b/scanpydoc/elegant_typehints.py
@@ -27,15 +27,26 @@ This extension modifies the created type annotations in two ways:
 
 """
 import inspect
-from collections import ChainMap
-from typing import Union, Mapping, Dict, Any, Type
+from collections import abc, ChainMap
+from functools import partial
+from pathlib import Path
+from typing import Union, Dict, Any, Type, Sequence, List, Tuple, Optional
 
 import sphinx_autodoc_typehints
+from sphinx_autodoc_typehints import format_annotation as _format_full
+from docutils import nodes
+from docutils.nodes import Node
+from docutils.parsers.rst.roles import set_classes
+from docutils.parsers.rst.states import Inliner, Struct
+from docutils.utils import SystemMessage, unescape
 from sphinx.application import Sphinx
 from sphinx.config import Config
+from docutils.parsers.rst import roles
 
 from . import _setup_sig, metadata
 
+
+HERE = Path(__file__).parent.resolve()
 
 qualname_overrides_default = {
     "anndata.base.AnnData": "anndata.AnnData",
@@ -49,9 +60,37 @@ qualname_overrides = ChainMap({}, qualname_overrides_default)
 
 def _init_vars(app: Sphinx, config: Config):
     qualname_overrides.update(config.qualname_overrides)
+    config.html_static_path.append(str(HERE / "static"))
 
 
-fa_orig = sphinx_autodoc_typehints.format_annotation
+def _format_terse(annotation: Type[Any]) -> str:
+    union_params = getattr(annotation, "__union_params__", None)
+
+    # display `Union[A, B]` as `A, B`
+    if getattr(annotation, "__origin__", None) is Union or union_params:
+        params = union_params or getattr(annotation, "__args__", None)
+        # Never use the `Optional` keyword in the displayed docs.
+        # Use the more verbose `, None` instead,
+        # as is the convention in the other large numerical packages
+        # if len(params or []) == 2 and getattr(params[1], '__qualname__', None) == 'NoneType':
+        #     return fa_orig(annotation)  # Optional[...]
+        return ", ".join(map(_format_terse, params))
+
+    # do not show the arguments of Mapping
+    if getattr(annotation, "__origin__", None) is abc.Mapping:
+        return ":py:class:`~typing.Mapping`"
+
+    # display dict as {k: v}
+    if getattr(annotation, "__origin__", None) is dict:
+        k, v = annotation.__args__
+        return f"{{{_format_terse(k)}: {_format_terse(v)}}}"
+
+    if inspect.isclass(annotation):
+        full_name = f"{annotation.__module__}.{annotation.__qualname__}"
+        override = qualname_overrides.get(full_name)
+        if override is not None:
+            return f":py:class:`~{override}`"
+    return _format_full(annotation)
 
 
 def format_annotation(annotation: Type[Any]) -> str:
@@ -66,32 +105,60 @@ def format_annotation(annotation: Type[Any]) -> str:
     Returns:
         reStructuredText describing the type
     """
-    union_params = getattr(annotation, "__union_params__", None)
-    # display `Union[A, B]` as `A, B`
-    if getattr(annotation, "__origin__", None) is Union or union_params:
-        params = union_params or getattr(annotation, "__args__", None)
-        # Never use the `Optional` keyword in the displayed docs.
-        # Use the more verbose `, None` instead,
-        # as is the convention in the other large numerical packages
-        # if len(params or []) == 2 and getattr(params[1], '__qualname__', None) == 'NoneType':
-        #     return fa_orig(annotation)  # Optional[...]
-        return ", ".join(map(format_annotation, params))
-    # do not show the arguments of Mapping
-    if getattr(annotation, "__origin__", None) is Mapping:
-        return ":class:`~typing.Mapping`"
-    if inspect.isclass(annotation):
-        full_name = f"{annotation.__module__}.{annotation.__qualname__}"
-        override = qualname_overrides.get(full_name)
-        if override is not None:
-            return f":py:class:`~{override}`"
-    return fa_orig(annotation)
+
+    curframe = inspect.currentframe()
+    calframe = inspect.getouterframes(curframe, 2)
+    if calframe[1][3] == "process_docstring":
+        return (
+            fr":annotation-terse:`{_escape(_format_terse(annotation))}`\ "
+            fr":annotation-full:`{_escape(_format_full(annotation))}`"
+        )
+    else:  # recursive use
+        return _format_full(annotation)
+
+
+def _role_annot(
+    name: str,
+    rawtext: str,
+    text: str,
+    lineno: int,
+    inliner: Inliner,
+    options: Dict[str, Any] = {},
+    content: Sequence[str] = (),
+    *,
+    additional_class: Optional[str] = None,
+) -> Tuple[List[Node], List[SystemMessage]]:
+    options = options.copy()
+    set_classes(options)
+    if additional_class is not None:
+        options["classes"] = options.get("classes", []).copy()
+        options["classes"].append(additional_class)
+    memo = Struct(
+        document=inliner.document, reporter=inliner.reporter, language=inliner.language
+    )
+    node = nodes.inline(unescape(rawtext), "", **options)
+    children, messages = inliner.parse(_unescape(text), lineno, memo, node)
+    node.extend(children)
+    return [node], messages
+
+
+def _escape(rst: str) -> str:
+    return rst.replace("`", "\\`")
+
+
+def _unescape(rst: str) -> str:
+    # TODO: IDK why the [ part is necessary.
+    return unescape(rst).replace("\\`", "`").replace("[", "\\[")
 
 
 @_setup_sig
 def setup(app: Sphinx) -> Dict[str, Any]:
     """Patches :mod:`sphinx_autodoc_typehints` for a more elegant display."""
     app.add_config_value("qualname_overrides", {}, "")
+    app.add_css_file("typehints.css")
     app.connect("config-inited", _init_vars)
     sphinx_autodoc_typehints.format_annotation = format_annotation
+    for name in ["annotation-terse", "annotation-full"]:
+        roles.register_canonical_role(name, partial(_role_annot, additional_class=name))
 
     return metadata

--- a/scanpydoc/elegant_typehints.py
+++ b/scanpydoc/elegant_typehints.py
@@ -112,8 +112,8 @@ def format_annotation(annotation: Type[Any]) -> str:
     calframe = inspect.getouterframes(curframe, 2)
     if calframe[1][3] == "process_docstring":
         return (
-            fr":annotation-terse:`{_escape(_format_terse(annotation))}`\ "
-            fr":annotation-full:`{_escape(_format_full(annotation))}`"
+            f":annotation-terse:`{_escape(_format_terse(annotation))}`\\ "
+            f":annotation-full:`{_escape(_format_full(annotation))}`"
         )
     else:  # recursive use
         return _format_full(annotation)
@@ -127,7 +127,7 @@ def _role_annot(
     inliner: Inliner,
     options: Dict[str, Any] = {},
     content: Sequence[str] = (),
-    *,
+    # *,  # https://github.com/ambv/black/issues/613
     additional_class: Optional[str] = None,
 ) -> Tuple[List[Node], List[SystemMessage]]:
     options = options.copy()

--- a/scanpydoc/elegant_typehints.py
+++ b/scanpydoc/elegant_typehints.py
@@ -30,7 +30,9 @@ import inspect
 from collections import abc, ChainMap
 from functools import partial
 from pathlib import Path
-from typing import Union, Dict, Any, Type, Sequence, List, Tuple, Optional
+from typing import Any, Union, Optional  # Meta
+from typing import Type, Mapping, Sequence  # ABC
+from typing import Dict, List, Tuple  # Concrete
 
 import sphinx_autodoc_typehints
 from sphinx_autodoc_typehints import format_annotation as _format_full
@@ -77,11 +79,11 @@ def _format_terse(annotation: Type[Any]) -> str:
         return ", ".join(map(_format_terse, params))
 
     # do not show the arguments of Mapping
-    if getattr(annotation, "__origin__", None) is abc.Mapping:
+    if getattr(annotation, "__origin__", None) in (abc.Mapping, Mapping):
         return ":py:class:`~typing.Mapping`"
 
     # display dict as {k: v}
-    if getattr(annotation, "__origin__", None) is dict:
+    if getattr(annotation, "__origin__", None) in (dict, Dict):
         k, v = annotation.__args__
         return f"{{{_format_terse(k)}: {_format_terse(v)}}}"
 

--- a/scanpydoc/static/typehints.css
+++ b/scanpydoc/static/typehints.css
@@ -1,13 +1,2 @@
-*:not(:hover) > .annotation-terse {
-    display: initial;
-}
-*:not(:hover) > .annotation-full {
-    display: none;
-}
-
-*:hover > .annotation-terse {
-    display: none;
-}
-*:hover > .annotation-full {
-    display: initial;
-}
+*:not(:hover) > .annotation-full  { display: none }
+*:hover       > .annotation-terse { display: none }

--- a/scanpydoc/static/typehints.css
+++ b/scanpydoc/static/typehints.css
@@ -1,0 +1,13 @@
+*:not(:hover) > .annotation-terse {
+    display: initial;
+}
+*:not(:hover) > .annotation-full {
+    display: none;
+}
+
+*:hover > .annotation-terse {
+    display: none;
+}
+*:hover > .annotation-full {
+    display: initial;
+}

--- a/tests/test_elegant_typehints.py
+++ b/tests/test_elegant_typehints.py
@@ -1,0 +1,29 @@
+from typing import Mapping, Any, Dict
+
+from scanpydoc.elegant_typehints import format_annotation, _format_terse, _format_full
+
+
+def test_default():
+    assert format_annotation(str) == ":py:class:`str`"
+
+
+def test_alternatives():
+    def process_docstring(a):
+        """Caller needs to be `process_docstring` to create both formats"""
+        return format_annotation(a)
+
+    assert process_docstring(str) == (
+        ":annotation-terse:`:py:class:\\`str\\``\\ "
+        ":annotation-full:`:py:class:\\`str\\``"
+    )
+
+
+def test_mapping():
+    assert _format_terse(Mapping[str, Any]) == ":py:class:`~typing.Mapping`"
+    assert _format_full(Mapping[str, Any]) == (
+        ":py:class:`~typing.Mapping`\\[:py:class:`str`, :py:data:`~typing.Any`]"
+    )
+
+
+def test_dict():
+    assert _format_terse(Dict[str, Any]) == "{:py:class:`str`: :py:data:`~typing.Any`}"


### PR DESCRIPTION
- [x] doesn’t hide punctuations, we need a way around it.
- [ ] CSS adding might not be optimal, see sphinx-doc/sphinx#1379
- [ ] Checking the call frame is also not elegant, but I see no other option to patch `format_annotation`, except for replacing the version of `process_docstring` that’s probably already installed as an event handler.

Take a look on [readthedocs](https://icb-scanpydoc.readthedocs-hosted.com/en/fancy-typehints/scanpydoc.elegant_typehints.html)! On hover, `{str: Any}` (setup’s return type) becomes `Dict[str, Any]`!

Fixes #3