### PR TITLE
Set sphinx-autodoc-typehints requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ test = [
     'scipy',  # to test overrides
 ]
 doc = [
-    'sphinx-autodoc-typehints',
+    'sphinx-autodoc-typehints>=1.7',
 ]
 
 [tool.black]


### PR DESCRIPTION
Using `scanpydoc==0.3.4` and `sphinx-autodoc-typehints==1.6.0`, building the docs for anndata and scanpy throws an exception with the following traceback:

```python
  File "/usr/local/lib/python3.7/site-packages/sphinx/ext/autodoc/__init__.py", line 463, in process_doc
    self.options, docstringlines)
  File "/usr/local/lib/python3.7/site-packages/sphinx/application.py", line 449, in emit
    return self.events.emit(event, *args)
  File "/usr/local/lib/python3.7/site-packages/sphinx/events.py", line 103, in emit
    results.append(callback(self.app, *args))
  File "/usr/local/lib/python3.7/site-packages/sphinx_autodoc_typehints.py", line 209, in process_docstring
    formatted_annotation = format_annotation(annotation)
  File "/usr/local/lib/python3.7/site-packages/scanpydoc/elegant_typehints.py", line 135, in format_annotation
    f":annotation-terse:`{_escape(_format_terse(annotation, fully_qualified))}`\\ "
  File "/usr/local/lib/python3.7/site-packages/scanpydoc/elegant_typehints.py", line 110, in _format_terse
    return _format_full(annotation, fully_qualified)
  File "/usr/local/lib/python3.7/site-packages/scanpydoc/elegant_typehints.py", line 85, in _format_full
    return _format_orig(annotation, fully_qualified)
TypeError: format_annotation() takes 1 positional argument but 2 were given
```

Updating `sphinx-autodoc-typehints==1.7.0` solved this for me.