### PR TITLE
Add test for forward refs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,14 +5,18 @@ branches:
   only:
   - master  # use PR builder only for other branches
 python:
-  - '3.6'
-  - '3.7'
-  - '3.8'
+- '3.6'
+# Travis uses old versions if you specify 3.x,
+# and elegant_typehints trigger a Python bug in those.
+# There seems to be no way to specify the newest patch version,
+# so I’ll just use the newest at the time of writing I guess.
+- '3.7.9'
+- '3.8.6'
 
 install:
-  - pip install flit codecov
-  - flit install --deps develop
+- pip install flit codecov
+- flit install --deps develop
 script:
-  - PYTHONPATH=. pytest --cov=scanpydoc --black
-  - rst2html.py --halt=2 README.rst >/dev/null
+- PYTHONPATH=. pytest --cov=scanpydoc --black
+- rst2html.py --halt=2 README.rst >/dev/null
 after_success: codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,9 @@ python:
 # Travis uses old versions if you specify 3.x,
 # and elegant_typehints trigger a Python bug in those.
 # There seems to be no way to specify the newest patch version,
-# so I’ll just use the newest at the time of writing I guess.
+# so I’ll just use the newest available at the time of writing.
 - '3.7.9'
-- '3.8.6'
+- '3.8.5'
 
 install:
 - pip install flit codecov

--- a/scanpydoc/elegant_typehints/return_tuple.py
+++ b/scanpydoc/elegant_typehints/return_tuple.py
@@ -43,7 +43,12 @@ def process_docstring(
     if what in ("class", "exception"):
         obj = obj.__init__
     obj = inspect.unwrap(obj)
-    ret_types = get_tuple_annot(get_type_hints(obj).get("return"))
+    try:
+        hints = get_type_hints(obj)
+    except (AttributeError, TypeError):
+        # Introspecting a slot wrapper will raise TypeError
+        return
+    ret_types = get_tuple_annot(hints.get("return"))
     if ret_types is None:
         return
 

--- a/scanpydoc/elegant_typehints/return_tuple.py
+++ b/scanpydoc/elegant_typehints/return_tuple.py
@@ -1,5 +1,6 @@
 import inspect
 import re
+from logging import getLogger
 from typing import get_type_hints, Any, Union, Optional, Type, Tuple, List
 
 from sphinx.application import Sphinx
@@ -8,6 +9,7 @@ from sphinx.ext.autodoc import Options
 from .formatting import format_both
 
 
+logger = getLogger(__name__)
 re_ret = re.compile("^:returns?: ")
 
 
@@ -47,6 +49,9 @@ def process_docstring(
         hints = get_type_hints(obj)
     except (AttributeError, TypeError):
         # Introspecting a slot wrapper will raise TypeError
+        return
+    except NameError as e:
+        check_bpo_34776(obj, e)
         return
     ret_types = get_tuple_annot(hints.get("return"))
     if ret_types is None:
@@ -92,3 +97,20 @@ def process_docstring(
 #     return_annotation: str,
 # ) -> Optional[Tuple[Optional[str], Optional[str]]]:
 #     return signature, return_annotation
+
+
+def check_bpo_34776(obj: Any, e: NameError):
+    import sys
+
+    ancient = sys.version_info < (3, 7)
+    old_3_7 = (3, 7) < sys.version_info < (3, 7, 6)
+    old_3_8 = (3, 8) < sys.version_info < (3, 8, 1)
+    if ancient or old_3_7 or old_3_8:
+        v = ".".join(map(str, sys.version_info[:3]))
+        logger.warning(
+            f"Error documenting {obj!r}: To avoid this, "
+            f"your Python version {v} must be at least 3.7.6 or 3.8.1. "
+            "For more information see https://bugs.python.org/issue34776"
+        )
+    else:
+        raise e  # No idea what happened

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,7 @@
+import importlib.util
 import typing as t
 from tempfile import NamedTemporaryFile
+from textwrap import dedent
 
 import pytest
 from docutils.nodes import document
@@ -49,3 +51,14 @@ def render() -> t.Callable[[Sphinx, document], str]:
         return writer.output
 
     return _render
+
+
+@pytest.fixture
+def make_module():
+    def make_module(name, code):
+        spec = importlib.util.spec_from_loader(name, loader=None)
+        mod = importlib.util.module_from_spec(spec)
+        exec(dedent(code), mod.__dict__)
+        return mod
+
+    return make_module

--- a/tests/test_elegant_typehints.py
+++ b/tests/test_elegant_typehints.py
@@ -292,6 +292,7 @@ def test_fwd_ref(app, make_module):
         if "Cannot treat a function defined as a local function" not in w
     ]
     assert not warnings, warnings
+    # TODO: actually reproduce #14
     assert "fwd_mod.A" in out, out
 
 

--- a/tests/test_elegant_typehints.py
+++ b/tests/test_elegant_typehints.py
@@ -258,6 +258,7 @@ def test_autodoc(app, _testmod, direc, base, sub):
     assert re.search(rf"Bases: <code[^>]*><span[^>]*>test\.{base}", out), out
 
 
+@pytest.mark.skipif(sys.version_info < (3, 7), reason="bpo-34776 only fixed on 3.7+")
 def test_fwd_ref(app, make_module):
     make_module(
         "fwd_mod",


### PR DESCRIPTION
Fixes #14 once ready

I still can’t reproduce #14 locally, but I can here! Seems to have to do with dataclasses:

https://github.com/theislab/scanpydoc/runs/1165147987

cc @ded8393