### PR TITLE
Display `Union[a, b]` as `a | b` (PEP 604)

### DIFF
--- a/scanpydoc/elegant_typehints/__init__.py
+++ b/scanpydoc/elegant_typehints/__init__.py
@@ -56,6 +56,7 @@ from docutils.parsers.rst import roles
 from sphinx.ext.autodoc import ClassDocumenter
 
 from .. import _setup_sig, metadata
+from .example import example_func
 
 
 HERE = Path(__file__).parent.resolve()
@@ -80,6 +81,9 @@ def _init_vars(app: Sphinx, config: Config):
     qualname_overrides.update(config.qualname_overrides)
     annotate_defaults = config.annotate_defaults
     config.html_static_path.append(str(HERE / "static"))
+
+
+example_func.__module__ = "scanpydoc.elegant_typehints"  # Make it show up here
 
 
 @_setup_sig

--- a/scanpydoc/elegant_typehints/example.py
+++ b/scanpydoc/elegant_typehints/example.py
@@ -1,0 +1,15 @@
+from typing import Dict, Union, Optional
+
+
+def example_func(a: Optional[str], b: Union[str, int, None] = None) -> Dict[str, int]:
+    """Example function
+
+    Hover over the paramter and return type annotations to see the long versions.
+
+    Args:
+        a: An example parameter
+        b: Another, with a default
+    Returns:
+        An example return value
+    """
+    pass

--- a/scanpydoc/elegant_typehints/formatting.py
+++ b/scanpydoc/elegant_typehints/formatting.py
@@ -49,15 +49,12 @@ def _format_terse(annotation: Type[Any], fully_qualified: bool = False) -> str:
     origin = getattr(annotation, "__origin__", None)
 
     union_params = getattr(annotation, "__union_params__", None)
-    # display `Union[A, B]` as `A, B`
+    # display `Union[A, B]` as `A | B`
     if origin is Union or union_params:
         params = union_params or getattr(annotation, "__args__", None)
         # Never use the `Optional` keyword in the displayed docs.
-        # Use the more verbose `, None` instead,
-        # as is the convention in the other large numerical packages
-        # if len(params or []) == 2 and getattr(params[1], '__qualname__', None) == 'NoneType':
-        #     return fa_orig(annotation)  # Optional[...]
-        return ", ".join(_format_terse(p, fully_qualified) for p in params)
+        # Use `| None` instead, similar to other large numerical packages.
+        return " | ".join(_format_terse(p, fully_qualified) for p in params)
 
     # do not show the arguments of Mapping
     if origin in (abc.Mapping, Mapping):
@@ -66,7 +63,10 @@ def _format_terse(annotation: Type[Any], fully_qualified: bool = False) -> str:
     # display dict as {k: v}
     if origin in (dict, Dict):
         k, v = annotation.__args__
-        return f"{{{_format_terse(k, fully_qualified)}: {_format_terse(v, fully_qualified)}}}"
+        return (
+            f"{{{_format_terse(k, fully_qualified)}: "
+            f"{_format_terse(v, fully_qualified)}}}"
+        )
 
     if origin is Literal or hasattr(annotation, "__values__"):
         values = getattr(annotation, "__args__", ()) or annotation.__values__

--- a/tests/test_elegant_typehints.py
+++ b/tests/test_elegant_typehints.py
@@ -167,7 +167,7 @@ def test_qualname_overrides_exception(app, _testmod):
 
 def test_qualname_overrides_recursive(app, _testmod):
     assert _format_terse(t.Union[_testmod.Class, str]) == (
-        r":py:class:`~test.Class`, :py:class:`str`"
+        r":py:class:`~test.Class` | :py:class:`str`"
     )
     assert _format_full(t.Union[_testmod.Class, str]) == (
         r":py:data:`~typing.Union`\["
@@ -179,7 +179,7 @@ def test_qualname_overrides_recursive(app, _testmod):
 
 def test_fully_qualified(app, _testmod):
     assert _format_terse(t.Union[_testmod.Class, str], True) == (
-        r":py:class:`test.Class`, :py:class:`str`"
+        r":py:class:`test.Class` | :py:class:`str`"
     )
     assert _format_full(t.Union[_testmod.Class, str], True) == (
         r":py:data:`typing.Union`\[" r":py:class:`test.Class`, " r":py:class:`str`" r"]"


### PR DESCRIPTION
Since [PEP 604](https://www.python.org/dev/peps/pep-0604/) is now in Python 3.10, `a | b` is now the official terse syntax for `Union[a, b]`.

Our initial question was to decide between

1. `a | b | c`

   - Used by all languages I’ve ever encountered that have syntax for this, as well as formal grammars, …
   - Makes sense: `|` is syntax for set unions in Python

2. `a, b, c`

   - Used by numpy docs, and I think Pandas at the time
   - Doesn’t make sense: In Python, that’s a tuple, in English, one doesn’t know if it means “and” or “or”!

3. `a, b, or c`

   - Makes sense: Is normal english

Back then, we decided for 2.

Nowadays, Python officially uses `|` and pandas switched to `a, b or c`, so the pros for 2. have vanished even more.

I think we should switch to the official syntax.