### PR TITLE
Remove rubric styling

### DIFF
--- a/scanpydoc/theme/static/css/scanpy.css
+++ b/scanpydoc/theme/static/css/scanpy.css
@@ -41,12 +41,6 @@
 
 /* Formatting of RTD markup: rubrics and sidebars and admonitions */
 
-/* rubric */
-.rst-content p.rubric {
-    margin-bottom: 6px;
-    font-weight: normal;
-}
-
 /* sidebar */
 .rst-content .sidebar {
     /* margin: 0px 0px 0px 12px; */


### PR DESCRIPTION
I was looking into https://github.com/theislab/scanpy/issues/1581, and saw examples headings were under the rubric class, which has custom styling applied here. I've previously been unhappy with how the "rubric" titles looked in the release notes. This PR removes the custom styling and I think looks much better in both places. It's not clear to me why this styling was added in the first place however, so I could be missing something.

# Change logs

## This PR

![image](https://user-images.githubusercontent.com/8238804/107327393-2d0e8e00-6b01-11eb-82c5-3e4bbcb910ca.png)

## Previous

![image](https://user-images.githubusercontent.com/8238804/107327354-1ff19f00-6b01-11eb-869f-d9b6d255f321.png)

# Examples sections for docs

## This PR

![image](https://user-images.githubusercontent.com/8238804/107327554-6ba44880-6b01-11eb-9695-34cd366b0f03.png)

## Previous

![image](https://user-images.githubusercontent.com/8238804/107327632-8971ad80-6b01-11eb-85d7-bff2bab0bd56.png)
