### PR TITLE
DocSearch

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -51,6 +51,10 @@ autosummary_generate = True
 add_module_names = False
 
 html_theme = "scanpydoc"
+html_theme_options = dict(
+    docsearch_project="scanpy",
+    docsearch_key="fa4304eb95d2134997e3729553a674b2",
+)
 html_context = dict(
     github_user="theislab", github_repo="scanpydoc", github_version="master"
 )

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -52,7 +52,7 @@ add_module_names = False
 
 html_theme = "scanpydoc"
 html_theme_options = dict(
-    docsearch_project="scanpy",
+    docsearch_index="scanpy",
     docsearch_key="fa4304eb95d2134997e3729553a674b2",
 )
 html_context = dict(

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -51,10 +51,6 @@ autosummary_generate = True
 add_module_names = False
 
 html_theme = "scanpydoc"
-html_theme_options = dict(
-    docsearch_index="scanpy",
-    docsearch_key="fa4304eb95d2134997e3729553a674b2",
-)
 html_context = dict(
     github_user="theislab", github_repo="scanpydoc", github_version="master"
 )

--- a/scanpydoc/theme/__init__.py
+++ b/scanpydoc/theme/__init__.py
@@ -9,7 +9,7 @@ Add to ``conf.py``:
 Theme options
 =============
 
-This theme only adds one configuration value:
+This theme adds the following configuration value, and the ones under docsearch_:
 
 .. confval:: accent_color
 
@@ -27,6 +27,39 @@ See ``sphinx_rtd_theme``’s :doc:`sphinx_rtd_theme:configuring`, e.g.:
        accent_color='rebeccapurple',
        display_version=False,
    )
+
+Docsearch
+---------
+
+These two configuration values are required to use docsearch:
+
+.. confval:: docsearch_key
+
+   :type: str
+
+   The API key provided by docsearch.
+
+.. confval:: docsearch_index
+
+   :type: str
+
+   The index name used by docsearch.
+
+.. confval:: docsearch_doc_version
+
+   :type: str
+   :default: ``'latest'`` or ``'stable'``
+
+   The documentation version searched.
+   The default is ``'stable'`` if ``READTHEDOCS_VERSION=stable`` is set,
+   and ``'latest'`` otherwise.
+
+.. confval:: docsearch_js_version
+
+   :type: str
+   :default: ``'2.6'``
+
+   The docsearch library version used.
 
 """
 

--- a/scanpydoc/theme/__init__.py
+++ b/scanpydoc/theme/__init__.py
@@ -9,7 +9,8 @@ Add to ``conf.py``:
 Theme options
 =============
 
-This theme adds the following configuration value, and the ones under docsearch_:
+This theme adds the following configuration option,
+and the ones under `docsearch options`_:
 
 .. confval:: accent_color
 
@@ -28,10 +29,12 @@ See ``sphinx_rtd_theme``’s :doc:`sphinx_rtd_theme:configuring`, e.g.:
        display_version=False,
    )
 
-Docsearch
----------
+Docsearch options
+-----------------
 
-These two configuration values are required to use docsearch:
+These two configuration values are required to use docsearch_:
+
+.. _docsearch: https://docsearch.algolia.com/
 
 .. confval:: docsearch_key
 
@@ -44,6 +47,8 @@ These two configuration values are required to use docsearch:
    :type: str
 
    The index name used by docsearch.
+
+The following configuration values are optional:
 
 .. confval:: docsearch_doc_version
 

--- a/scanpydoc/theme/layout.html
+++ b/scanpydoc/theme/layout.html
@@ -30,7 +30,7 @@
     indexName: '{{ theme_docsearch_index }}',
     inputSelector: '#rtd-search-form > input[name="q"]',
     algoliaOptions: { facetFilters: ['version:{{ theme_docsearch_doc_version or safe_version }}'] },
-    debug: true,
+    debug: false,
   }))
 </script>
 {% endif %}

--- a/scanpydoc/theme/layout.html
+++ b/scanpydoc/theme/layout.html
@@ -1,9 +1,29 @@
 {% extends "sphinx_rtd_theme/layout.html" %}
+
 {%- block extrahead %}
 {{ super() }}
 {% if theme_accent_color %}
 <style>
 :root { --accent-color: {{ theme_accent_color }} }
 </style>
+{% endif %}
+{% if theme_docsearch_key %}
+<link rel=stylesheet href="https://cdn.jsdelivr.net/npm/docsearch.js@{{ theme_docsearch_js_version }}/dist/cdn/docsearch.min.css"/>
+{% endif %}
+{% endblock %}
+
+{% block scripts %}
+{{ super() }}
+{% if theme_docsearch_key %}
+<script src="https://cdn.jsdelivr.net/npm/docsearch.js@{{ theme_docsearch_js_version }}/dist/cdn/docsearch.min.js"></script>
+<script>
+  document.addEventListener('DOMContentLoaded', () => docsearch({
+    apiKey: '{{ theme_docsearch_key }}',
+    indexName: '{{ theme_docsearch_project }}',
+    inputSelector: '#rtd-search-form > input[name="q"]',
+    algoliaOptions: { facetFilters: ['version:{{ version }}'] },
+    debug: false,
+  }))
+</script>
 {% endif %}
 {% endblock %}

--- a/scanpydoc/theme/layout.html
+++ b/scanpydoc/theme/layout.html
@@ -12,6 +12,8 @@
 {% endif %}
 {% endblock %}
 
+{% set safe_version = version if version in ["latest", "stable"] else "latest" %}
+
 {% block scripts %}
 {{ super() }}
 {% if theme_docsearch_key %}
@@ -21,7 +23,7 @@
     apiKey: '{{ theme_docsearch_key }}',
     indexName: '{{ theme_docsearch_project }}',
     inputSelector: '#rtd-search-form > input[name="q"]',
-    algoliaOptions: { facetFilters: ['version:{{ version }}'] },
+    algoliaOptions: { facetFilters: ['version:{{ safe_version }}'] },
     debug: false,
   }))
 </script>

--- a/scanpydoc/theme/layout.html
+++ b/scanpydoc/theme/layout.html
@@ -7,7 +7,7 @@
 :root { --accent-color: {{ theme_accent_color }} }
 </style>
 {% endif %}
-{% if theme_docsearch_key %}
+{% if theme_docsearch_key and theme_docsearch_index %}
 <link rel=stylesheet href="https://cdn.jsdelivr.net/npm/docsearch.js@{{ theme_docsearch_js_version }}/dist/cdn/docsearch.min.css"/>
 {% endif %}
 {% endblock %}
@@ -16,14 +16,14 @@
 
 {% block scripts %}
 {{ super() }}
-{% if theme_docsearch_key %}
+{% if theme_docsearch_key and theme_docsearch_index %}
 <script src="https://cdn.jsdelivr.net/npm/docsearch.js@{{ theme_docsearch_js_version }}/dist/cdn/docsearch.min.js"></script>
 <script>
   document.addEventListener('DOMContentLoaded', () => docsearch({
     apiKey: '{{ theme_docsearch_key }}',
-    indexName: '{{ theme_docsearch_project }}',
+    indexName: '{{ theme_docsearch_index }}',
     inputSelector: '#rtd-search-form > input[name="q"]',
-    algoliaOptions: { facetFilters: ['version:{{ safe_version }}'] },
+    algoliaOptions: { facetFilters: ['version:{{ theme_docsearch_doc_version or safe_version }}'] },
     debug: false,
   }))
 </script>

--- a/scanpydoc/theme/layout.html
+++ b/scanpydoc/theme/layout.html
@@ -1,14 +1,20 @@
 {% extends "sphinx_rtd_theme/layout.html" %}
 
+<!-- Have to use htmltitle to include this earlier as our style -->
+{%- block htmltitle %}
+{{ super() }}
+{% if theme_docsearch_key and theme_docsearch_index %}
+<link rel=stylesheet href="https://cdn.jsdelivr.net/npm/docsearch.js@{{ theme_docsearch_js_version }}/dist/cdn/docsearch.min.css"/>
+{% endif %}
+{%- endblock -%}
+
+<!-- Styles that come last -->
 {%- block extrahead %}
 {{ super() }}
 {% if theme_accent_color %}
 <style>
 :root { --accent-color: {{ theme_accent_color }} }
 </style>
-{% endif %}
-{% if theme_docsearch_key and theme_docsearch_index %}
-<link rel=stylesheet href="https://cdn.jsdelivr.net/npm/docsearch.js@{{ theme_docsearch_js_version }}/dist/cdn/docsearch.min.css"/>
 {% endif %}
 {% endblock %}
 

--- a/scanpydoc/theme/layout.html
+++ b/scanpydoc/theme/layout.html
@@ -22,7 +22,7 @@
     indexName: '{{ theme_docsearch_project }}',
     inputSelector: '#rtd-search-form > input[name="q"]',
     algoliaOptions: { facetFilters: ['version:{{ version }}'] },
-    debug: true,
+    debug: false,
   }))
 </script>
 {% endif %}

--- a/scanpydoc/theme/layout.html
+++ b/scanpydoc/theme/layout.html
@@ -30,7 +30,7 @@
     indexName: '{{ theme_docsearch_index }}',
     inputSelector: '#rtd-search-form > input[name="q"]',
     algoliaOptions: { facetFilters: ['version:{{ theme_docsearch_doc_version or safe_version }}'] },
-    debug: false,
+    debug: true,
   }))
 </script>
 {% endif %}

--- a/scanpydoc/theme/layout.html
+++ b/scanpydoc/theme/layout.html
@@ -22,7 +22,7 @@
     indexName: '{{ theme_docsearch_project }}',
     inputSelector: '#rtd-search-form > input[name="q"]',
     algoliaOptions: { facetFilters: ['version:{{ version }}'] },
-    debug: false,
+    debug: true,
   }))
 </script>
 {% endif %}

--- a/scanpydoc/theme/static/css/scanpy.css
+++ b/scanpydoc/theme/static/css/scanpy.css
@@ -16,16 +16,16 @@
 .wy-nav-side, .wy-side-scroll { overflow-x: visible; }  /* make popup window visible */
 .wy-side-scroll { width: 100%; scrollbar-width: none; }  /* hide scrollbar without hack */
 .wy-side-scroll::-webkit-scrollbar { display: none; }  /* … or with less hackery that is */
-.algolia-autocomplete { display: block !important; }  /* make searchbar fill the entire width */
+.algolia-autocomplete { display: block; }  /* make searchbar fill the entire width */
 .algolia-autocomplete .ds-dropdown-menu *[class^="ds-dataset-"] {
-    position: fixed !important;  /* For some reason this, not its parent, needs to be used */
-    max-width: 1000px !important;
-    width: 80vw !important;
+    position: fixed;  /* For some reason this, not its parent, needs to be used */
+    max-width: 1000px;
+    width: 80vw;
     box-shadow:  /* And since we’re using this, it needs the shadow */
       0 1px 0 0 rgba(0,0,0,.2),
       0 2px 3px 0 rgba(0,0,0,.1);
 }
-.algolia-autocomplete .ds-dropdown-menu { box-shadow: none !important; }
+.algolia-autocomplete .ds-dropdown-menu { box-shadow: none; }
 
 /* Custom classes */
 

--- a/scanpydoc/theme/static/css/scanpy.css
+++ b/scanpydoc/theme/static/css/scanpy.css
@@ -13,19 +13,14 @@
 
 /* DocSearch adaptations */
 
-.wy-nav-side, .wy-side-scroll { overflow-x: visible; }  /* make popup window visible */
-.wy-side-scroll { width: 100%; scrollbar-width: none; }  /* hide scrollbar without hack */
-.wy-side-scroll::-webkit-scrollbar { display: none; }  /* … or with less hackery that is */
-.algolia-autocomplete { display: block; }  /* make searchbar fill the entire width */
-.algolia-autocomplete .ds-dropdown-menu *[class^="ds-dataset-"] {
-    position: fixed;  /* For some reason this, not its parent, needs to be used */
-    max-width: 1000px;
-    width: 80vw;
-    box-shadow:  /* And since we’re using this, it needs the shadow */
-      0 1px 0 0 rgba(0,0,0,.2),
-      0 2px 3px 0 rgba(0,0,0,.1);
+.wy-nav-side { overflow: visible; }
+.wy-side-scroll { overflow: inherit; }
+
+/* Making it a bit wider */
+.algolia-autocomplete .ds-dropdown-menu {
+  max-width: 1000px;
+  min-width: 80vw;
 }
-.algolia-autocomplete .ds-dropdown-menu { box-shadow: none; }
 
 /* Custom classes */
 

--- a/scanpydoc/theme/static/css/scanpy.css
+++ b/scanpydoc/theme/static/css/scanpy.css
@@ -10,6 +10,14 @@
 .wy-side-nav-search a.icon-home { font-size: 2em; color: var(--accent-color) }
 .wy-side-nav-search a.icon-home::before { content: none }
 
+/* DocSearch adaptations */
+
+.wy-nav-side { overflow: visible; }
+.wy-side-scroll { overflow: inherit; }
+.algolia-autocomplete .ds-dropdown-menu {
+    max-width: 1000px;
+    min-width: 80vw;
+}
 
 /* Custom classes */
 

--- a/scanpydoc/theme/static/css/scanpy.css
+++ b/scanpydoc/theme/static/css/scanpy.css
@@ -9,14 +9,19 @@
 .wy-side-nav-search input[type="text"] { border-width: 0 }
 .wy-side-nav-search a.icon-home { font-size: 2em; color: var(--accent-color) }
 .wy-side-nav-search a.icon-home::before { content: none }
+.wy-menu li a { overflow: hidden; text-overflow: ellipsis; }  /* display ellipsis in long items */
 
 /* DocSearch adaptations */
 
-.wy-nav-side { overflow: visible; }
-.wy-side-scroll { overflow: inherit; }
-.algolia-autocomplete .ds-dropdown-menu {
-    max-width: 1000px;
-    min-width: 80vw;
+.wy-nav-side, .wy-side-scroll { overflow-x: visible; }  /* make popup window visible */
+.wy-side-scroll { width: 100%; scrollbar-width: none; }  /* hide scrollbar without hack */
+.wy-side-scroll::-webkit-scrollbar { display: none; }  /* … or with less hackery that is */
+.algolia-autocomplete { display: block !important; }  /* make searchbar fill the entire width */
+.algolia-autocomplete .ds-dropdown-menu *[class^="ds-dataset-"] {
+    position: fixed !important;
+    max-width: 1000px !important;
+    width: 80vw !important;
+    box-shadow: 0 1px 0 0 rgba(0,0,0,.2),0 2px 3px 0 rgba(0,0,0,.1);
 }
 
 /* Custom classes */

--- a/scanpydoc/theme/static/css/scanpy.css
+++ b/scanpydoc/theme/static/css/scanpy.css
@@ -18,11 +18,14 @@
 .wy-side-scroll::-webkit-scrollbar { display: none; }  /* … or with less hackery that is */
 .algolia-autocomplete { display: block !important; }  /* make searchbar fill the entire width */
 .algolia-autocomplete .ds-dropdown-menu *[class^="ds-dataset-"] {
-    position: fixed !important;
+    position: fixed !important;  /* For some reason this, not its parent, needs to be used */
     max-width: 1000px !important;
     width: 80vw !important;
-    box-shadow: 0 1px 0 0 rgba(0,0,0,.2),0 2px 3px 0 rgba(0,0,0,.1);
+    box-shadow:  /* And since we’re using this, it needs the shadow */
+      0 1px 0 0 rgba(0,0,0,.2),
+      0 2px 3px 0 rgba(0,0,0,.1);
 }
+.algolia-autocomplete .ds-dropdown-menu { box-shadow: none !important; }
 
 /* Custom classes */
 

--- a/scanpydoc/theme/theme.conf
+++ b/scanpydoc/theme/theme.conf
@@ -19,5 +19,6 @@ style_nav_header_background =
 # added by scanpydoc
 accent_color =
 docsearch_key =
-docsearch_project =
+docsearch_index =
+docsearch_doc_version =
 docsearch_js_version = 2.6

--- a/scanpydoc/theme/theme.conf
+++ b/scanpydoc/theme/theme.conf
@@ -18,3 +18,6 @@ style_external_links = False
 style_nav_header_background =
 # added by scanpydoc
 accent_color =
+docsearch_key =
+docsearch_project =
+docsearch_js_version = 2.6


### PR DESCRIPTION
[In Action](https://icb-scanpydoc.readthedocs-hosted.com/en/doc-search/scanpydoc.theme.html)

Fixes #25

TODO 

- [x] Indices: Which projects are being indexed in our `scanpy` project index? How to configure that? Should searching in e.g. scanpydoc itself yield scanpy results, or should we have e.g. one index for scanpydocs and one for anndata & scanpy?

  Currently our setup means that scanpydoc would return search results for scanpy only, not itself, which is very wrong.

- [x] Doc versions: Currently it uses the version it’s built under, as long as that version is “latest” or “stable”. Does that make sense?