### PR TITLE
DocSearch: Add debug, increase hits per page

### DIFF
--- a/scanpydoc/theme/layout.html
+++ b/scanpydoc/theme/layout.html
@@ -29,8 +29,11 @@
     apiKey: '{{ theme_docsearch_key }}',
     indexName: '{{ theme_docsearch_index }}',
     inputSelector: '#rtd-search-form > input[name="q"]',
-    algoliaOptions: { facetFilters: ['version:{{ theme_docsearch_doc_version or safe_version }}'] },
-    debug: false,
+    algoliaOptions: {
+      facetFilters: ['version:{{ theme_docsearch_doc_version or safe_version }}'],
+      hitsPerPage: 10,
+    },
+    debug: {{ theme_docsearch_debug }},
   }))
 </script>
 {% endif %}

--- a/scanpydoc/theme/theme.conf
+++ b/scanpydoc/theme/theme.conf
@@ -22,3 +22,4 @@ docsearch_key =
 docsearch_index =
 docsearch_doc_version =
 docsearch_js_version = 2.6
+docsearch_debug = false


### PR DESCRIPTION
Fixes #29 

Add option for debug, since that'll come in handy with styling. Also increase hits from 5 to 8. Would be nice if this was done dynamically with screen size.