### PR TITLE
Fix DLTypedField for pydata sphinx theme

### DIFF
--- a/scanpydoc/definition_list_typed_field.py
+++ b/scanpydoc/definition_list_typed_field.py
@@ -64,7 +64,8 @@ class DLTypedField(PyTypedField):
 
         field_name = nodes.field_name("", self.label)
         assert not self.can_collapse
-        body_node = self.list_type()
+        # “simple” for pydata sphinx theme
+        body_node = self.list_type(classes=["simple"])
         for field_arg, content in items:
             body_node += handle_item(field_arg, content)
         field_body = nodes.field_body("", body_node)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,19 +2,14 @@ import importlib.util
 import linecache
 import sys
 import typing as t
-from tempfile import NamedTemporaryFile
 from textwrap import dedent
 from uuid import uuid4
 
 import pytest
 from docutils.nodes import document
-from docutils.writers import Writer
 from sphinx.application import Sphinx
-from sphinx.io import read_doc
 from sphinx.testing.fixtures import make_app, test_params  # noqa
 from sphinx.testing.path import path as STP
-from sphinx.util import rst
-from sphinx.util.docutils import sphinx_domains
 
 
 @pytest.fixture
@@ -24,21 +19,6 @@ def make_app_setup(make_app, tmp_path) -> t.Callable[..., Sphinx]:
         return make_app(srcdir=STP(tmp_path), confoverrides=conf)
 
     return make_app_setup
-
-
-@pytest.fixture
-def parse() -> t.Callable[[Sphinx, str], document]:
-    def _parse(app: Sphinx, code: str) -> document:
-        with NamedTemporaryFile("w+", suffix=".rst", dir=app.env.srcdir) as f:
-            f.write(code)
-            f.flush()
-            app.env.prepare_settings(f.name)
-            with sphinx_domains(app.env), rst.default_role(
-                f.name, app.config.default_role
-            ):
-                return read_doc(app, app.env, f.name)
-
-    return _parse
 
 
 @pytest.fixture

--- a/tests/test_definition_list_typed_field.py
+++ b/tests/test_definition_list_typed_field.py
@@ -1,6 +1,7 @@
 import pytest
 from sphinx.application import Sphinx
 from sphinx.builders.html import StandaloneHTMLBuilder
+from sphinx.testing.restructuredtext import parse
 from sphinx.writers.html import HTMLTranslator
 from sphinx.writers.html5 import HTML5Translator
 
@@ -38,7 +39,7 @@ def test_apps_separate(app, make_app_setup):
 
 
 @pytest.mark.parametrize("code,n", [(params_code, 2), (params_code_single, 1)])
-def test_convert_params(app, parse, code, n):
+def test_convert_params(app, code, n):
     # the directive class is PyModuleLevel → PyObject → ObjectDescription
     # ObjectDescription.run uses a DocFieldTransformer to transform members
     # the signature of each Directive(
@@ -69,7 +70,7 @@ def test_convert_params(app, parse, code, n):
 
 @pytest.mark.parametrize("translator", [HTMLTranslator, HTML5Translator])
 @pytest.mark.parametrize("code", [params_code, params_code_single])
-def test_render_params_html4(app, parse, render, translator, code):
+def test_render_params_html4(app, render, translator, code):
     app.config.html4_writer = translator is HTMLTranslator
     assert app.builder.__class__ is StandaloneHTMLBuilder
     assert app.builder.default_translator_class is translator

--- a/tests/test_elegant_typehints.py
+++ b/tests/test_elegant_typehints.py
@@ -6,13 +6,14 @@ from pathlib import Path
 
 
 try:  # 3.8 additions
-    from typing import Literal, get_args, get_origin
+    from typing import Literal, get_origin
 except ImportError:
-    from typing_extensions import Literal, get_args, get_origin
+    from typing_extensions import Literal, get_origin
 
 import pytest
 import sphinx_autodoc_typehints as sat
 from sphinx.application import Sphinx
+from sphinx.testing.restructuredtext import parse
 
 from scanpydoc.elegant_typehints.formatting import (
     _format_full,
@@ -182,7 +183,7 @@ def test_fully_qualified(app, _testmod):
     assert _format_full(t.Union[_testmod.Class, str], app.config) is None
 
 
-def test_classes_get_added(app, parse):
+def test_classes_get_added(app):
     doc = parse(app, r":annotation-full:`:py:class:\`str\``")
     assert doc[0].tagname == "paragraph"
     assert doc[0][0].tagname == "inline"


### PR DESCRIPTION
They make definition list terms without HTML class `display: flex`, ruining spacing