### PR TITLE
Use classifier nodes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ version-file = 'src/scanpydoc/_version.py'
 [tool.hatch.envs.docs]
 features = ['doc']
 [tool.hatch.envs.docs.scripts]
-build = 'sphinx-build -M html docs docs/_build/html'
+build = 'sphinx-build -M html docs docs/_build'
 
 [[tool.hatch.envs.test.matrix]]
 python = ['3.8', '3.9', '3.10', '3.11']

--- a/src/scanpydoc/definition_list_typed_field.py
+++ b/src/scanpydoc/definition_list_typed_field.py
@@ -7,6 +7,7 @@ with a derivative :class:`DLTypedField`, which renders item items
 
 from __future__ import annotations
 
+from collections.abc import Generator
 from typing import Any
 
 from docutils import nodes
@@ -47,26 +48,29 @@ class DLTypedField(PyTypedField):
 
         def handle_item(
             fieldarg: str, content: list[nodes.inline]
-        ) -> nodes.definition_list_item:
-            head = nodes.inline()
-            head += make_refs(self.rolename, fieldarg, addnodes.literal_strong)
+        ) -> Generator[nodes.Node, None, None]:
+            term = nodes.term()
+            term += make_refs(self.rolename, fieldarg, addnodes.literal_strong)
+
             field_type = types.pop(fieldarg, None)
             if field_type is not None:
-                head += nodes.Text(" : ")
                 if len(field_type) == 1 and isinstance(field_type[0], nodes.Text):
                     (text_node,) = field_type  # type: nodes.Text
-                    head += make_refs(
+                    classifier_content = make_refs(
                         self.typerolename, text_node.astext(), addnodes.literal_emphasis
                     )
                 else:
-                    head += field_type
+                    classifier_content = field_type
+                term += [
+                    # https://github.com/sphinx-doc/sphinx/issues/10815
+                    nodes.Text(" "),
+                    nodes.classifier("×", "", *classifier_content),
+                ]
 
-            # Contents are wrapped into a span for pydata sphinx theme
-            head_wrap = nodes.term("", "", head)
-            body_content = nodes.paragraph("", "", *content)
-            body = nodes.definition("", body_content)
+            def_content = nodes.paragraph("", "", *content)
+            definition = nodes.definition("", def_content)
 
-            return nodes.definition_list_item("", head_wrap, body)
+            return nodes.definition_list_item("", term, definition)
 
         field_name = nodes.field_name("", self.label)
         assert not self.can_collapse

--- a/src/scanpydoc/definition_list_typed_field.py
+++ b/src/scanpydoc/definition_list_typed_field.py
@@ -64,6 +64,8 @@ class DLTypedField(PyTypedField):
                 term += [
                     # https://github.com/sphinx-doc/sphinx/issues/10815
                     nodes.Text(" "),
+                    # Sphinx tries to fixup classifiers without rawsource,
+                    # but for this expects attributes we don’t have. Thus “×”.
                     nodes.classifier("×", "", *classifier_content),
                 ]
 

--- a/src/scanpydoc/definition_list_typed_field.py
+++ b/src/scanpydoc/definition_list_typed_field.py
@@ -7,7 +7,6 @@ with a derivative :class:`DLTypedField`, which renders item items
 
 from __future__ import annotations
 
-from collections.abc import Generator
 from typing import Any
 
 from docutils import nodes
@@ -48,7 +47,7 @@ class DLTypedField(PyTypedField):
 
         def handle_item(
             fieldarg: str, content: list[nodes.inline]
-        ) -> Generator[nodes.Node, None, None]:
+        ) -> nodes.definition_list_item:
             term = nodes.term()
             term += make_refs(self.rolename, fieldarg, addnodes.literal_strong)
 


### PR DESCRIPTION
DLTypedFields currently don’t use the semantic markup it could, this fixes that.