### PR TITLE
Fix path

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,7 @@
     "python.testing.pytestArgs": ["-v"],
     "python.testing.unittestEnabled": false,
     "python.testing.pytestEnabled": true,
+    "python.terminal.activateEnvironment": false,
     "[python]": {
         "editor.defaultFormatter": "ms-python.black-formatter",
         "editor.formatOnSave": true,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -59,7 +59,7 @@ html_context = dict(
     use_repository_button=True,
 )
 
-rtd_links_prefix = Path("src")
+rtd_links_prefix = "src"
 
 
 def setup(app: Sphinx):

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -59,8 +59,7 @@ html_context = dict(
     use_repository_button=True,
 )
 
-# proj/doc/.. → proj
-project_dir = HERE.parent
+rtd_links_prefix = Path("src")
 
 
 def setup(app: Sphinx):

--- a/src/scanpydoc/rtd_github_links/__init__.py
+++ b/src/scanpydoc/rtd_github_links/__init__.py
@@ -27,7 +27,7 @@ Configuration
 
 Uses the following config values in ``conf.py``::
 
-    project_dir: Path = ...  # default: Path.cwd()
+    rtd_links_prefix: Path = ...  # default: Path('.')
 
     # sphinx book theme style
     html_context = dict(
@@ -41,8 +41,8 @@ Uses the following config values in ``conf.py``::
         github_version=...,
     )
 
-The ``project_dir`` is used to figure out the .py file path relative to the git root,
-that is to construct the path in the github URL.
+The ``rtd_links_prefix`` is for figuring out the .py file path relative to the git root,
+that is to construct the path in the GitHub URL.
 
 Which ``html_context`` style you want to use depends on your theme, e.g.
 :doc:`Sphinx Book Theme <sphinx_book_theme:index>`.
@@ -78,13 +78,13 @@ from sphinx.config import Config
 from .. import _setup_sig, metadata
 
 
-project_dir = None  # type: Path
-github_base_url = None  # type: str
+rtd_links_prefix: Path = None
+github_base_url: str = None
 
 
 def _init_vars(app: Sphinx, config: Config):
     """Called when ``conf.py`` has been loaded."""
-    global github_base_url, project_dir
+    global github_base_url, rtd_links_prefix
     _check_html_context(config)
     try:
         github_base_url = "https://github.com/{github_user}/{github_repo}/tree/{github_version}".format_map(
@@ -94,7 +94,7 @@ def _init_vars(app: Sphinx, config: Config):
         github_base_url = "{repository_url}/tree/{repository_branch}".format_map(
             config.html_context
         )
-    project_dir = Path(config.project_dir)
+    rtd_links_prefix = Path(config.rtd_links_prefix)
 
 
 def _get_obj_module(qualname: str) -> tuple[Any, ModuleType]:
@@ -151,12 +151,7 @@ def github_url(qualname: str) -> str:
     except Exception:
         print(f"Error in github_url({qualname!r}):", file=sys.stderr)
         raise
-    try:
-        path = PurePosixPath(Path(module.__file__).resolve().relative_to(project_dir))
-    except ValueError as e:
-        raise RuntimeError(
-            "scanpydoc.rtd_github_links only works in dev install. See docs."
-        ) from e
+    path = PurePosixPath(*module.__name__.split("."))
     start, end = _get_linenos(obj)
     fragment = f"#L{start}-L{end}" if start and end else ""
     return f"{github_base_url}/{path}{fragment}"

--- a/src/scanpydoc/rtd_github_links/__init__.py
+++ b/src/scanpydoc/rtd_github_links/__init__.py
@@ -27,7 +27,7 @@ Configuration
 
 Uses the following config values in ``conf.py``::
 
-    rtd_links_prefix: Path = ...  # default: Path('.')
+    rtd_links_prefix: os.PathLike | str = ...  # default: '.'
 
     # sphinx book theme style
     html_context = dict(
@@ -94,7 +94,7 @@ def _init_vars(app: Sphinx, config: Config):
         github_base_url = "{repository_url}/tree/{repository_branch}".format_map(
             config.html_context
         )
-    rtd_links_prefix = Path(config.rtd_links_prefix)
+    rtd_links_prefix = PurePosixPath(config.rtd_links_prefix)
 
 
 def _get_obj_module(qualname: str) -> tuple[Any, ModuleType]:
@@ -151,7 +151,7 @@ def github_url(qualname: str) -> str:
     except Exception:
         print(f"Error in github_url({qualname!r}):", file=sys.stderr)
         raise
-    path = PurePosixPath(*module.__name__.split("."))
+    path = rtd_links_prefix / PurePosixPath(*module.__name__.split("."))
     start, end = _get_linenos(obj)
     fragment = f"#L{start}-L{end}" if start and end else ""
     return f"{github_base_url}/{path}{fragment}"

--- a/src/scanpydoc/rtd_github_links/__init__.py
+++ b/src/scanpydoc/rtd_github_links/__init__.py
@@ -151,13 +151,12 @@ def github_url(qualname: str) -> str:
     except Exception:
         print(f"Error in github_url({qualname!r}):", file=sys.stderr)
         raise
-    try:  # only works when installed in dev mode
+    try:
         path = PurePosixPath(Path(module.__file__).resolve().relative_to(project_dir))
-    except ValueError:
-        # no dev mode or something from another package
-        path = PurePosixPath(*module.__file__.split("/")[-2:])
-        if (project_dir / "src").is_dir():
-            path = "src" / path
+    except ValueError as e:
+        raise RuntimeError(
+            "scanpydoc.rtd_github_links only works in dev install. See docs."
+        ) from e
     start, end = _get_linenos(obj)
     fragment = f"#L{start}-L{end}" if start and end else ""
     return f"{github_base_url}/{path}{fragment}"

--- a/tests/test_rtd_github_links.py
+++ b/tests/test_rtd_github_links.py
@@ -1,5 +1,5 @@
 from dataclasses import Field
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 import pytest
 from _pytest.monkeypatch import MonkeyPatch
@@ -11,14 +11,20 @@ HERE = Path(__file__).parent
 
 
 @pytest.fixture
-def env(monkeypatch: MonkeyPatch):
-    monkeypatch.setattr("scanpydoc.rtd_github_links.github_base_url", ".")
-    monkeypatch.setattr("scanpydoc.rtd_github_links.project_dir", HERE.parent)
+def _env(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.setattr("scanpydoc.rtd_github_links.github_base_url", "x")
 
 
-def test_as_function(env):
-    pth = "./src/scanpydoc/rtd_github_links/__init__.py"
-    assert github_url("scanpydoc.rtd_github_links") == pth
+@pytest.fixture(params=[".", "src"])
+def pfx(monkeypatch: MonkeyPatch, _env, request):
+    pfx = PurePosixPath(request.param)
+    monkeypatch.setattr("scanpydoc.rtd_github_links.rtd_links_prefix", pfx)
+    return pfx
+
+
+def test_as_function(pfx):
+    pth = "x" / pfx / "scanpydoc/rtd_github_links/__init__.py"
+    assert github_url("scanpydoc.rtd_github_links") == str(pth)
     s, e = _get_linenos(github_url)
     assert github_url("scanpydoc.rtd_github_links.github_url") == f"{pth}#L{s}-L{e}"
 


### PR DESCRIPTION
Logic seems to break when documenting nested packages, e.g.

```diff
-https://github.com/theislab/scanpydoc/tree/master/src/elegant_typehints/__init__.py#L94-L123
+https://github.com/theislab/scanpydoc/tree/master/src/scanpydoc/elegant_typehints/__init__.py#L94-L123
````