### PR TITLE
More robust paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,6 @@ jobs:
       - name: dependencies
         run: |
           pip install --upgrade pip wheel
-          pip install -e .[test,typehints]
+          pip install .[test,typehints]
       - name: tests
         run: pytest --color=yes

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,3 @@
-import sys
 from datetime import datetime
 from importlib.metadata import metadata
 from pathlib import Path
@@ -7,9 +6,6 @@ from sphinx.application import Sphinx
 
 
 HERE = Path(__file__).parent
-
-# necessary for rtd_gh_links’ linkcode support
-sys.path.insert(0, HERE.parent / "src")
 
 # Clean build env
 for file in HERE.glob("scanpydoc.*.rst"):

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -45,6 +45,7 @@ templates_path = ["_templates"]
 
 # Generate .rst stubs for modules using autosummary
 autosummary_generate = True
+autosummary_ignore_module_all = False
 # Don’t add module paths to documented functions’ names
 add_module_names = False
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ source = 'vcs'
 version-file = 'src/scanpydoc/_version.py'
 
 [tool.hatch.envs.docs]
+python = '3.11'
 features = ['doc']
 [tool.hatch.envs.docs.scripts]
 build = 'sphinx-build -M html docs docs/_build'

--- a/src/scanpydoc/elegant_typehints/__init__.py
+++ b/src/scanpydoc/elegant_typehints/__init__.py
@@ -57,7 +57,7 @@ from sphinx.config import Config
 from sphinx.ext.autodoc import ClassDocumenter
 
 from .. import _setup_sig, metadata
-from .example import example_func
+from .example import example_func  # noqa: F401
 
 
 HERE = Path(__file__).parent.resolve()
@@ -86,9 +86,6 @@ def _init_vars(app: Sphinx, config: Config):
         # override default for “typehints_defaults”
         config.typehints_defaults = "braces"
     config.html_static_path.append(str(HERE / "static"))
-
-
-example_func.__module__ = "scanpydoc.elegant_typehints"  # Make it show up here
 
 
 @_setup_sig

--- a/src/scanpydoc/elegant_typehints/__init__.py
+++ b/src/scanpydoc/elegant_typehints/__init__.py
@@ -57,7 +57,10 @@ from sphinx.config import Config
 from sphinx.ext.autodoc import ClassDocumenter
 
 from .. import _setup_sig, metadata
-from .example import example_func  # noqa: F401
+from .example import example_func
+
+
+__all__ = ["example_func", "setup"]
 
 
 HERE = Path(__file__).parent.resolve()

--- a/src/scanpydoc/rtd_github_links/__init__.py
+++ b/src/scanpydoc/rtd_github_links/__init__.py
@@ -8,13 +8,6 @@ This extension does two things:
 
    .. code:: python
 
-      import sys
-      from pathlib import Path
-
-      HERE = Path(__file__).parent
-      # make sure modules are import from the right place
-      sys.path.insert(0, HERE.parent / "src")
-
       extensions = [
           "scanpydoc",
           "sphinx.ext.linkcode",


### PR DESCRIPTION
TODO:

- [x] check if `example_func` still shows up in docs