### PR TITLE
Add prose extension for numpydoc

### DIFF
--- a/docs/_templates/autosummary/module.rst
+++ b/docs/_templates/autosummary/module.rst
@@ -1,0 +1,40 @@
+{# https://raw.githubusercontent.com/sphinx-doc/sphinx/master/sphinx/ext/autosummary/templates/autosummary/module.rst #}
+{% extends "!autosummary/module.rst" %}
+
+{% block classes %}
+{% if classes -%}
+Classes
+-------
+
+{%- for class in classes -%}
+{%- if not class.startswith('_') %}
+.. autoclass:: {{ class }}
+   :members:
+{%- endif -%}
+{%- endfor -%}
+{%- endif %}
+{% endblock %}
+
+{% block functions %}
+{% if functions -%}
+Functions
+---------
+
+{%- for function in functions -%}
+{%- if not function.startswith('_') and not function.startswith('example_') %}
+.. autofunction:: {{ function }}
+{%- endif -%}
+{%- endfor -%}
+{%- if functions | select('search', '^example_') | first %}
+
+Examples
+--------
+
+{%- for function in functions -%}
+{%- if function.startswith('example_') %}
+.. autofunction:: {{ function }}
+{%- endif -%}
+{%- endfor -%}
+{%- endif -%}
+{%- endif %}
+{% endblock %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -8,6 +8,8 @@ from datetime import datetime
 from datetime import timezone as tz
 from importlib.metadata import metadata
 
+from jinja2.tests import TESTS
+
 
 if TYPE_CHECKING:
     from sphinx.application import Sphinx
@@ -50,6 +52,17 @@ autosummary_generate = True
 autosummary_ignore_module_all = False
 # Don’t add module paths to documented functions’ names
 add_module_names = False
+
+
+def test_search(value: str, pattern: str) -> bool:
+    """Tests if `pattern` can be found in `value`."""
+    import re
+
+    return bool(re.search(pattern, value))
+
+
+# IDK if there’s a good way to do this without modifying the global list
+TESTS["search"] = test_search
 
 html_theme = "scanpydoc"
 html_theme_options = dict(

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -53,6 +53,9 @@ autosummary_ignore_module_all = False
 # Don’t add module paths to documented functions’ names
 add_module_names = False
 
+napoleon_google_docstring = False
+napoleon_numpy_docstring = True
+
 
 def test_search(value: str, pattern: str) -> bool:
     """Tests if `pattern` can be found in `value`."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,8 @@ length-sort = true
 lines-after-imports = 2
 known-first-party = ['scanpydoc']
 required-imports = ["from __future__ import annotations"]
+[tool.ruff.lint.pydocstyle]
+convention = 'numpy'
 
 [tool.mypy]
 strict = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ ignore = [
 ]
 [tool.ruff.lint.flake8-type-checking]
 strict = true
+exempt-modules = []
 [tool.ruff.lint.isort]
 length-sort = true
 lines-after-imports = 2

--- a/src/scanpydoc/__init__.py
+++ b/src/scanpydoc/__init__.py
@@ -20,11 +20,14 @@ metadata = dict(version=__version__, env_version=1, parallel_read_safe=True)
 # Can’t seem to be able to do this in numpydoc style:
 # https://github.com/sphinx-doc/sphinx/issues/5887
 setup_sig_str = """\
-Args:
-    app: Sphinx app to set this :term:`sphinx:extension` up for
+Arguments
+---------
+app
+    Sphinx app to set this :term:`sphinx:extension` up for
 
-Returns:
-    :ref:`Metadata <sphinx:ext-metadata>` for this extension.
+Returns
+-------
+:ref:`Metadata <sphinx:ext-metadata>` for this extension.
 """
 
 C = TypeVar("C", bound=Callable[..., Any])

--- a/src/scanpydoc/autosummary_generate_imported.py
+++ b/src/scanpydoc/autosummary_generate_imported.py
@@ -7,19 +7,19 @@
 
 from __future__ import annotations
 
-import sys
 from typing import TYPE_CHECKING
-
-
-if sys.version_info >= (3, 11):
-    from typing import Never
-else:  # pragma: no cover
-    from typing import NoReturn as Never
 
 from . import _setup_sig
 
 
 if TYPE_CHECKING:
+    import sys
+
+    if sys.version_info >= (3, 11):
+        from typing import Never
+    else:  # pragma: no cover
+        from typing import NoReturn as Never
+
     from sphinx.application import Sphinx
 
 

--- a/src/scanpydoc/elegant_typehints/__init__.py
+++ b/src/scanpydoc/elegant_typehints/__init__.py
@@ -53,10 +53,11 @@ from collections import ChainMap
 from dataclasses import dataclass
 
 from sphinx.ext.autodoc import ClassDocumenter
+from sphinx.ext.napoleon import NumpyDocstring  # type: ignore[attr-defined]
 
 from scanpydoc import metadata, _setup_sig
 
-from .example import example_func
+from .example import example_func_prose, example_func_tuple
 
 
 if TYPE_CHECKING:
@@ -66,7 +67,7 @@ if TYPE_CHECKING:
     from sphinx.application import Sphinx
 
 
-__all__ = ["example_func", "setup"]
+__all__ = ["example_func_prose", "example_func_tuple", "setup"]
 
 
 HERE = Path(__file__).parent.resolve()
@@ -123,7 +124,9 @@ def setup(app: Sphinx) -> dict[str, Any]:
     )
 
     from ._return_tuple import process_docstring  # , process_signature
+    from ._return_patch_numpydoc import _parse_returns_section
 
+    NumpyDocstring._parse_returns_section = _parse_returns_section  # type: ignore[method-assign,assignment]  # noqa: SLF001
     app.connect("autodoc-process-docstring", process_docstring)
 
     return metadata

--- a/src/scanpydoc/elegant_typehints/__init__.py
+++ b/src/scanpydoc/elegant_typehints/__init__.py
@@ -47,7 +47,7 @@ This extension modifies the created type annotations in four ways:
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 from pathlib import Path
 from collections import ChainMap
 from dataclasses import dataclass
@@ -61,6 +61,7 @@ from .example import example_func_prose, example_func_tuple
 
 
 if TYPE_CHECKING:
+    from typing import Any
     from collections.abc import Callable
 
     from sphinx.config import Config

--- a/src/scanpydoc/elegant_typehints/_formatting.py
+++ b/src/scanpydoc/elegant_typehints/_formatting.py
@@ -24,12 +24,16 @@ def typehints_formatter(annotation: type[Any], config: Config) -> str | None:
     Can be used as ``typehints_formatter`` for :mod:`sphinx_autodoc_typehints`,
     to respect the ``qualname_overrides`` option.
 
-    Args:
-        annotation: A type or class used as type annotation.
-        config: Sphinx config containing ``sphinx-autodoc-typehints``’s options.
+    Arguments
+    ---------
+    annotation
+        A type or class used as type annotation.
+    config
+        Sphinx config containing ``sphinx-autodoc-typehints``’s options.
 
-    Returns:
-        reStructuredText describing the type
+    Returns
+    -------
+    reStructuredText describing the type
     """
     if inspect.isclass(annotation) and annotation.__module__ == "builtins":
         return None

--- a/src/scanpydoc/elegant_typehints/_formatting.py
+++ b/src/scanpydoc/elegant_typehints/_formatting.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import sys
 import inspect
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 
 if sys.version_info >= (3, 10):
@@ -15,6 +15,8 @@ from scanpydoc import elegant_typehints
 
 
 if TYPE_CHECKING:
+    from typing import Any
+
     from sphinx.config import Config
 
 

--- a/src/scanpydoc/elegant_typehints/_return_patch_numpydoc.py
+++ b/src/scanpydoc/elegant_typehints/_return_patch_numpydoc.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import re
 from typing import TYPE_CHECKING
 
+from sphinx_autodoc_typehints import format_annotation
+
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Generator
@@ -16,7 +18,9 @@ def _process_return(lines: Iterable[str]) -> Generator[str, None, None]:
     for line in lines:
         m = re.fullmatch(r"(?P<param>\w+)\s+:\s+(?P<type>[\w.]+)", line)
         if m:
-            yield f'**{m["param"]}** : :class:`~{m["type"]}`'
+            # TODO: pass in the object
+            typ = format_annotation(m.group("type"))
+            yield f'**{m["param"]}** : {typ}'
         else:
             yield line
 

--- a/src/scanpydoc/elegant_typehints/_return_patch_numpydoc.py
+++ b/src/scanpydoc/elegant_typehints/_return_patch_numpydoc.py
@@ -1,32 +1,16 @@
 from __future__ import annotations
 
-import re
 from typing import TYPE_CHECKING
-
-from sphinx_autodoc_typehints import format_annotation
 
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable, Generator
-
     from sphinx.ext.napoleon import NumpyDocstring  # type: ignore[attr-defined]
 
 __all__ = ["_parse_returns_section"]
 
 
-def _process_return(lines: Iterable[str]) -> Generator[str, None, None]:
-    for line in lines:
-        m = re.fullmatch(r"(?P<param>\w+)\s+:\s+(?P<type>[\w.]+)", line)
-        if m:
-            # TODO: pass in the object
-            typ = format_annotation(m.group("type"))
-            yield f'**{m["param"]}** : {typ}'
-        else:
-            yield line
-
-
 def _parse_returns_section(self: NumpyDocstring, section: str) -> list[str]:  # noqa: ARG001
-    lines_raw = list(_process_return(self._dedent(self._consume_to_next_section())))
+    lines_raw = list(self._dedent(self._consume_to_next_section()))
     if lines_raw[0] == ":":
         # Remove the “:” inserted by sphinx-autodoc-typehints
         # https://github.com/tox-dev/sphinx-autodoc-typehints/blob/a5c091f725da8374347802d54c16c3d38833d41c/src/sphinx_autodoc_typehints/patches.py#L66

--- a/src/scanpydoc/elegant_typehints/_return_patch_numpydoc.py
+++ b/src/scanpydoc/elegant_typehints/_return_patch_numpydoc.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Generator
+
+    from sphinx.ext.napoleon import NumpyDocstring  # type: ignore[attr-defined]
+
+__all__ = ["_parse_returns_section"]
+
+
+def _process_return(lines: Iterable[str]) -> Generator[str, None, None]:
+    for line in lines:
+        m = re.fullmatch(r"(?P<param>\w+)\s+:\s+(?P<type>[\w.]+)", line)
+        if m:
+            yield f'**{m["param"]}** : :class:`~{m["type"]}`'
+        else:
+            yield line
+
+
+def _parse_returns_section(self: NumpyDocstring, section: str) -> list[str]:  # noqa: ARG001
+    lines_raw = list(_process_return(self._dedent(self._consume_to_next_section())))
+    if lines_raw[0] == ":":
+        # Remove the “:” inserted by sphinx-autodoc-typehints
+        # https://github.com/tox-dev/sphinx-autodoc-typehints/blob/a5c091f725da8374347802d54c16c3d38833d41c/src/sphinx_autodoc_typehints/patches.py#L66
+        lines_raw.pop(0)
+    lines = self._format_block(":returns: ", lines_raw)
+    if lines and lines[-1]:
+        lines.append("")
+    return lines

--- a/src/scanpydoc/elegant_typehints/_return_tuple.py
+++ b/src/scanpydoc/elegant_typehints/_return_tuple.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import re
 import sys
 import inspect
-from typing import TYPE_CHECKING, Any, Union, get_args, get_origin, get_type_hints
+from typing import TYPE_CHECKING, Union, get_args, get_origin, get_type_hints
 from typing import Tuple as t_Tuple  # noqa: UP035
 from logging import getLogger
 
@@ -11,6 +11,7 @@ from sphinx_autodoc_typehints import format_annotation
 
 
 if TYPE_CHECKING:
+    from typing import Any
     from collections.abc import Sequence
 
     from sphinx.application import Sphinx

--- a/src/scanpydoc/elegant_typehints/example.py
+++ b/src/scanpydoc/elegant_typehints/example.py
@@ -1,17 +1,33 @@
 from __future__ import annotations
 
 
-def example_func(
+def example_func_prose(
     a: str | None, b: str | int | None = None
 ) -> dict[str, int]:  # pragma: no cover
-    """Example function.
+    """Example function with a paragraph return section.
 
-    Hover over the parameter and return type annotations to see the long versions.
+    Parameters
+    ----------
+    a
+        An example parameter
+    b
+        Another, with a default
 
-    Args:
-        a: An example parameter
-        b: Another, with a default
-    Returns:
-        An example return value
+    Returns
+    -------
+    An example dict
     """
     return {}
+
+
+def example_func_tuple() -> tuple[int, str]:  # pragma: no cover
+    """Example function with return tuple.
+
+    Returns
+    -------
+    x
+        An example int
+    y
+        An example str
+    """
+    return (1, "foo")

--- a/src/scanpydoc/rtd_github_links/__init__.py
+++ b/src/scanpydoc/rtd_github_links/__init__.py
@@ -191,12 +191,15 @@ def _module_path(obj: _SourceObjectType, module: ModuleType) -> PurePosixPath:
 def github_url(qualname: str) -> str:
     """Get the full GitHub URL for some object’s qualname.
 
-    Args:
-        qualname: The full qualified name of a function, class, method or module
+    Parameters
+    ----------
+    qualname
+        The full qualified name of a function, class, method or module
 
-    Returns:
-        A GitHub URL derived from the :confval:`html_context`
-        or the :confval:`html_theme_options`.
+    Returns
+    -------
+    A GitHub URL derived from the :confval:`html_context`
+    or the :confval:`html_theme_options`.
     """
     try:
         obj, module = _get_obj_module(qualname)

--- a/src/scanpydoc/rtd_github_links/__init__.py
+++ b/src/scanpydoc/rtd_github_links/__init__.py
@@ -61,7 +61,7 @@ from __future__ import annotations
 import sys
 import inspect
 from types import ModuleType
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 from pathlib import Path, PurePosixPath
 from importlib import import_module
 
@@ -72,7 +72,7 @@ from scanpydoc import metadata, _setup_sig
 
 if TYPE_CHECKING:
     from types import CodeType, FrameType, MethodType, FunctionType, TracebackType
-    from typing import TypeAlias
+    from typing import Any, TypeAlias
     from collections.abc import Callable
 
     _SourceObjectType: TypeAlias = (

--- a/src/scanpydoc/rtd_github_links/_linkcode.py
+++ b/src/scanpydoc/rtd_github_links/_linkcode.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Literal, TypedDict, cast, overload
+from typing import TYPE_CHECKING, TypedDict, cast, overload
 
 
 class PyInfo(TypedDict):
@@ -20,7 +20,7 @@ class JSInfo(TypedDict):
 
 
 if TYPE_CHECKING:
-    from typing import TypeAlias
+    from typing import Literal, TypeAlias
 
     Domain = Literal["py", "c", "cpp", "javascript"]
     DomainInfo: TypeAlias = PyInfo | CInfo | JSInfo

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ import sys
 import linecache
 import importlib.util
 from uuid import uuid4
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 from textwrap import dedent
 
 import pytest
@@ -14,6 +14,7 @@ import pytest
 
 if TYPE_CHECKING:
     from types import ModuleType
+    from typing import Any
     from pathlib import Path
     from collections.abc import Callable, Generator
 

--- a/tests/test_elegant_typehints.py
+++ b/tests/test_elegant_typehints.py
@@ -23,6 +23,9 @@ import pytest
 import sphinx_autodoc_typehints as sat
 from sphinx.ext import napoleon
 from sphinx.errors import ExtensionError
+from sphinx_autodoc_typehints.patches import (
+    napoleon_numpy_docstring_return_type_processor,
+)
 
 from scanpydoc.elegant_typehints._formatting import typehints_formatter
 from scanpydoc.elegant_typehints._return_tuple import process_docstring
@@ -86,6 +89,9 @@ def process_doc(app: Sphinx) -> ProcessDoc:
             name = fn.__name__
         else:
             name = "???"
+        napoleon_numpy_docstring_return_type_processor(
+            app, "function", name, fn, None, lines
+        )
         if run_napoleon:
             napoleon._process_docstring(app, "function", name, fn, None, lines)  # noqa: SLF001
         sat.process_docstring(app, "function", name, fn, None, lines)

--- a/tests/test_rtd_github_links.py
+++ b/tests/test_rtd_github_links.py
@@ -134,7 +134,9 @@ def test_app(monkeypatch: MonkeyPatch, make_app_setup: Callable[..., Sphinx]) ->
             id="basic",
         ),
         pytest.param(
-            *("elegant_typehints", "example_func", "elegant_typehints/example.py"),
+            "elegant_typehints",
+            "example_func_prose",
+            "elegant_typehints/example.py",
             id="reexport",
         ),
     ],

--- a/tests/test_rtd_github_links.py
+++ b/tests/test_rtd_github_links.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import re
 import sys
 import textwrap
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING
 from pathlib import Path, PurePosixPath
 from importlib import import_module
 
@@ -27,6 +27,7 @@ from scanpydoc.rtd_github_links._linkcode import (
 
 if TYPE_CHECKING:
     from types import ModuleType
+    from typing import Literal
     from collections.abc import Callable
 
     from sphinx.application import Sphinx


### PR DESCRIPTION
Adds scanpy’s “prose return sections” code to scanpydoc.