### PR TITLE
(fix): handle no docs in source code

### DIFF
--- a/src/scanpydoc/rtd_github_links/__init__.py
+++ b/src/scanpydoc/rtd_github_links/__init__.py
@@ -171,6 +171,10 @@ def _get_linenos(obj: _SourceObjectType) -> tuple[int, int] | tuple[None, None]:
     """Get an object’s line numbers."""
     try:
         lines, start = inspect.getsourcelines(obj)
+    # https://github.com/python/cpython/blob/main/Lib/inspect.py#L949-L1006
+    # means an OSError is raised if the source is not found,
+    # as is the case with collections.abc.Mapping.
+    # A TypeError indicates a builtin class.
     except (TypeError, OSError):
         return None, None
     else:

--- a/src/scanpydoc/rtd_github_links/__init__.py
+++ b/src/scanpydoc/rtd_github_links/__init__.py
@@ -171,7 +171,7 @@ def _get_linenos(obj: _SourceObjectType) -> tuple[int, int] | tuple[None, None]:
     """Get an object’s line numbers."""
     try:
         lines, start = inspect.getsourcelines(obj)
-    except TypeError:
+    except (TypeError, OSError):
         return None, None
     else:
         return start, start + len(lines) - 1

--- a/src/scanpydoc/rtd_github_links/__init__.py
+++ b/src/scanpydoc/rtd_github_links/__init__.py
@@ -171,7 +171,7 @@ def _get_linenos(obj: _SourceObjectType) -> tuple[int, int] | tuple[None, None]:
     """Get an object’s line numbers."""
     try:
         lines, start = inspect.getsourcelines(obj)
-    # https://github.com/python/cpython/blob/main/Lib/inspect.py#L949-L1006
+    # https://docs.python.org/3/library/inspect.html#inspect.getsourcelines
     # means an OSError is raised if the source is not found,
     # as is the case with collections.abc.Mapping.
     # A TypeError indicates a builtin class.

--- a/tests/test_rtd_github_links.py
+++ b/tests/test_rtd_github_links.py
@@ -8,6 +8,7 @@ import textwrap
 from typing import TYPE_CHECKING
 from pathlib import Path, PurePosixPath
 from importlib import import_module
+from collections.abc import Mapping
 
 import pytest
 from sphinx.config import Config
@@ -147,6 +148,11 @@ def test_as_function(
     obj = getattr(import_module(f"scanpydoc.{module}"), name)
     s, e = _get_linenos(obj)
     assert github_url(f"scanpydoc.{module}.{name}") == f"{prefix}/{obj_path}#L{s}-L{e}"
+
+
+def test_no_line_nos_for_builtin_source() -> None:
+    start, end = _get_linenos(Mapping)
+    assert start is end is None
 
 
 def test_get_github_url_only_annotation(prefix: PurePosixPath) -> None:

--- a/tests/test_rtd_github_links.py
+++ b/tests/test_rtd_github_links.py
@@ -150,8 +150,9 @@ def test_as_function(
     assert github_url(f"scanpydoc.{module}.{name}") == f"{prefix}/{obj_path}#L{s}-L{e}"
 
 
-def test_no_line_nos_for_builtin_source() -> None:
-    start, end = _get_linenos(Mapping)
+@pytest.mark.parametrize("cls", [dict, Mapping])
+def test_no_line_nos_for_unavailable_source(cls: type) -> None:
+    start, end = _get_linenos(cls)
     assert start is end is None
 
 


### PR DESCRIPTION
See https://github.com/python/cpython/blob/main/Lib/inspect.py#L949-L1006 for the source code yielding the error

Error raised from CI here: https://github.com/scverse/anndata/pull/1997

Under most circumstances, blanket catching an `OSError` seems like a bad idea, but I'm not sure ripping the messages out of the source code and checking them one-by-one is a much better idea, especially since `OSError` is the documented behavior: https://docs.python.org/3/library/inspect.html#inspect.getsourcelines