### PR TITLE
chore: Sphinx 9 compat robustness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,7 @@ jobs:
           hatch run ${{ matrix.env.name }}:run-cov -v --color=yes -n auto --junitxml=test-data/test-results.xml
           hatch run ${{ matrix.env.name }}:cov-combine
           hatch run ${{ matrix.env.name }}:coverage xml
+          hatch run ${{ matrix.env.name }}:cov-report
       - name: upload coverage
         if: ${{ !cancelled() }}
         uses: codecov/codecov-action@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,14 +61,15 @@ jobs:
         if: ${{ !cancelled() }}
         uses: codecov/codecov-action@v5
         with:
-          token: c66a2830-d3c7-4ae7-a230-21aef89dcf65
+          use_oidc: true
           flags: ${{ matrix.env.name }}
           fail_ci_if_error: true
       - name: Upload test results
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
+        uses: codecov/codecov-action@v5
         with:
-          token: c66a2830-d3c7-4ae7-a230-21aef89dcf65
+          report_type: test_results
+          use_oidc: true
           flags: ${{ matrix.env.name }}
           fail_ci_if_error: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,8 @@ jobs:
   test:
     needs: get-environments
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write # for codecov OIDC
     strategy:
       matrix:
         env: ${{ fromJSON(needs.get-environments.outputs.envs) }}

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,14 +1,20 @@
+# https://docs.readthedocs.io/en/stable/config-file/v2.html
 version: 2
+submodules:
+  include: all
 build:
   os: ubuntu-24.04
   tools:
-    python: "3.12"
-python:
-  install:
-    - method: pip
-      path: .
-      extra_requirements:
-        - doc
-sphinx:
-  configuration: docs/conf.py
-  fail_on_warning: true
+    python: "3.14"
+  jobs:
+    post_checkout:
+      # unshallow so version can be derived from tag
+      - git fetch --unshallow || true
+    create_environment:
+      - asdf plugin add uv
+      - asdf install uv latest
+      - asdf global uv latest
+    build:
+      html:
+        - uvx hatch run docs:build
+        - mv docs/_build $READTHEDOCS_OUTPUT

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,15 +5,6 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Debug current File",
-            "type": "debugpy",
-            "request": "launch",
-            "program": "${file}",
-            "pythonArgs": ["-Xfrozen_modules=off"],
-            "console": "internalConsole",
-            "justMyCode": false,
-        },
-        {
             "name": "Build Documentation",
             "type": "debugpy",
             "request": "launch",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
-    "python.analysis.typeCheckingMode": "strict",
+    "python.languageServer": "None",
+    "ty.disableLanguageServices": false,
     "python.testing.pytestArgs": ["-vv", "--color=yes"],
     "python.testing.pytestEnabled": true,
     "[python]": {

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,6 +28,7 @@ extensions = [
 intersphinx_mapping = dict(
     python=("https://docs.python.org/3", None),
     jinja=("https://jinja.palletsprojects.com/en/2.10.x/", None),
+    docutils=("https://sphinx-docutils.readthedocs.io/en/latest/", None),
     sphinx=("https://www.sphinx-doc.org/en/master/", None),
     sphinx_book_theme=("https://sphinx-book-theme.readthedocs.io/en/stable/", None),
     # examples
@@ -73,6 +74,11 @@ html_theme_options = dict(
 )
 
 rtd_links_prefix = PurePosixPath("src")
+
+suppress_warnings = [
+    # when documenting DLTypedField, s-a-t tries to get its .list_type’s typehints
+    "sphinx_autodoc_typehints.guarded_import",
+]
 
 
 def setup(app: Sphinx) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,9 +102,12 @@ clean = 'git clean -fdX {args:docs}'
 open = 'python3 -m webbrowser -t docs/_build/html/index.html'
 
 [tool.hatch.envs.hatch-test]
+dependencies = ['ipykernel', 'pytest-cov'] # VS Code integration
 features = ['test', 'typehints', 'myst']
 [[tool.hatch.envs.hatch-test.matrix]]
 python = ['3.12', '3.14']
+[[tool.hatch.envs.hatch-test.matrix]]
+python = ['3.14']
 
 [tool.pytest]
 addopts = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,7 +102,7 @@ clean = 'git clean -fdX {args:docs}'
 open = 'python3 -m webbrowser -t docs/_build/html/index.html'
 
 [tool.hatch.envs.hatch-test]
-dependencies = ['ipykernel', 'pytest-cov'] # VS Code integration
+extra-dependencies = ['ipykernel', 'pytest-cov'] # VS Code integration
 features = ['test', 'typehints', 'myst']
 [[tool.hatch.envs.hatch-test.matrix]]
 python = ['3.12', '3.14']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,13 +92,14 @@ source = 'vcs'
 version-file = 'src/scanpydoc/_version.py'
 
 [tool.hatch.envs.default]
+installer = 'uv'
 dependencies = ['types-docutils']
 [tool.hatch.envs.docs]
-python = '3.13'
 features = ['doc']
 [tool.hatch.envs.docs.scripts]
-build = 'sphinx-build -M html docs docs/_build'
-clean = 'git clean -fdX docs'
+build = 'sphinx-build -M html docs docs/_build -W {args}'
+clean = 'git clean -fdX {args:docs}'
+open = 'python3 -m webbrowser -t docs/_build/html/index.html'
 
 [tool.hatch.envs.hatch-test]
 features = ['test', 'typehints', 'myst']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,7 +105,7 @@ features = ['test', 'typehints', 'myst']
 [[tool.hatch.envs.hatch-test.matrix]]
 python = ['3.12', '3.14']
 
-[tool.pytest.ini_options]
+[tool.pytest]
 addopts = [
     '--import-mode=importlib',
     '-psphinx.testing.fixtures',
@@ -113,6 +113,9 @@ addopts = [
 filterwarnings = [
     'error',
     'ignore:The frontend.Option:DeprecationWarning',
+    'ignore::sphinx.deprecation.RemovedInSphinx11Warning:myst_parser',
+    # https://github.com/sphinx-doc/sphinx/issues/14270
+    'ignore:The mapping interface for autodoc options objects is deprecated:sphinx.deprecation.RemovedInSphinx11Warning',
 ]
 
 [tool.coverage.run]

--- a/src/scanpydoc/definition_list_typed_field.py
+++ b/src/scanpydoc/definition_list_typed_field.py
@@ -20,7 +20,7 @@ from . import metadata, _setup_sig
 
 
 if TYPE_CHECKING:
-    from typing import Any
+    from typing import Any, ClassVar
     from collections.abc import Iterable
 
     from sphinx.application import Sphinx
@@ -38,8 +38,8 @@ class DLTypedField(PyTypedField):
     it will be used instead of the default :class:`~sphinx.domains.python.PyTypedField`.
     """
 
-    #: Override the list type
-    list_type: type[nodes.definition_list] = nodes.definition_list  # type: ignore[assignment]
+    list_type: ClassVar = nodes.definition_list  # type: ignore[misc,assignment]
+    """Override the list type."""
 
     def make_field(  # type: ignore[override]
         self,

--- a/src/scanpydoc/elegant_typehints/__init__.py
+++ b/src/scanpydoc/elegant_typehints/__init__.py
@@ -53,8 +53,6 @@ from pathlib import Path
 from collections import ChainMap
 from dataclasses import dataclass
 
-from sphinx.ext.autodoc import ClassDocumenter
-
 from scanpydoc import metadata, _setup_sig
 from scanpydoc.elegant_typehints._role_mapping import RoleMapping
 
@@ -164,15 +162,9 @@ def setup(app: Sphinx) -> dict[str, Any]:
 
     app.config["typehints_formatter"] = PickleableCallable(typehints_formatter)
 
-    from ._autodoc_patch import dir_head_adder
+    from . import _return_tuple, _autodoc_patch
 
-    ClassDocumenter.add_directive_header = dir_head_adder(  # type: ignore[method-assign,assignment]
-        qualname_overrides,
-        ClassDocumenter.add_directive_header,
-    )
-
-    from . import _return_tuple
-
+    _autodoc_patch.setup(app)
     _return_tuple.setup(app)
 
     return metadata

--- a/src/scanpydoc/elegant_typehints/_autodoc_patch.py
+++ b/src/scanpydoc/elegant_typehints/_autodoc_patch.py
@@ -3,46 +3,45 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 from functools import wraps
 
+from sphinx.ext.autodoc import ClassDocumenter
+
+from . import qualname_overrides
+
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping, Callable
-
-    from sphinx.ext.autodoc import ClassDocumenter
+    from sphinx.application import Sphinx
     from docutils.statemachine import StringList
 
 
-def dir_head_adder(
-    qualname_overrides: Mapping[tuple[str | None, str], tuple[str | None, str]],
-    orig: Callable[[ClassDocumenter, str], None],
-) -> Callable[[ClassDocumenter, str], None]:
-    @wraps(orig)
-    def add_directive_header(self: ClassDocumenter, sig: str) -> None:
-        orig(self, sig)
-        lines = self.directive.result
-        inferred_role, direc = (
-            ("py:exc", "py:exception")
-            if isinstance(self.object, type) and issubclass(self.object, BaseException)
-            else ("py:class", "py:class")
-        )
-        for (old_role, old_name), (new_role, new_name) in qualname_overrides.items():
-            role = inferred_role if new_role is None else new_role
-            # Currently, autodoc doesn’t link to bases using :exc:
-            lines.replace(
-                f":{old_role or 'py:class'}:`{old_name}`", f":{role}:`{new_name}`"
-            )
-            # But maybe in the future it will
-            lines.replace(f":{role}:`{old_name}`", f":{role}:`{new_name}`")
-            if any("." not in name for name in (old_name, new_name)):
-                continue  # pragma: no cover
-            old_mod, old_cls = old_name.rsplit(".", 1)
-            new_mod, new_cls = new_name.rsplit(".", 1)
-            replace_multi_suffix(
-                lines,
-                (f".. {direc}:: {old_cls}", f"   :module: {old_mod}"),
-                (f".. {direc}:: {new_cls}", f"   :module: {new_mod}"),
-            )
+orig = ClassDocumenter.add_directive_header
 
-    return add_directive_header
+
+@wraps(orig)
+def add_directive_header(self: ClassDocumenter, sig: str) -> None:
+    orig(self, sig)
+    lines = self.directive.result
+    inferred_role, direc = (
+        ("py:exc", "py:exception")
+        if isinstance(self.object, type) and issubclass(self.object, BaseException)
+        else ("py:class", "py:class")
+    )
+    for (old_role, old_name), (new_role, new_name) in qualname_overrides.items():
+        role = inferred_role if new_role is None else new_role
+        # Currently, autodoc doesn’t link to bases using :exc:
+        lines.replace(
+            f":{old_role or 'py:class'}:`{old_name}`", f":{role}:`{new_name}`"
+        )
+        # But maybe in the future it will
+        lines.replace(f":{role}:`{old_name}`", f":{role}:`{new_name}`")
+        if any("." not in name for name in (old_name, new_name)):
+            continue  # pragma: no cover
+        old_mod, old_cls = old_name.rsplit(".", 1)
+        new_mod, new_cls = new_name.rsplit(".", 1)
+        replace_multi_suffix(
+            lines,
+            (f".. {direc}:: {old_cls}", f"   :module: {old_mod}"),
+            (f".. {direc}:: {new_cls}", f"   :module: {new_mod}"),
+        )
 
 
 def replace_multi_suffix(
@@ -63,3 +62,9 @@ def replace_multi_suffix(
         return
     lines[l + 0] = prefix + new[0] + suffix
     lines[l + 1] = prefix + new[1]
+
+
+def setup(app: Sphinx) -> None:
+    # no support for new autodoc
+    if getattr(app.config, "autodoc_use_legacy_class_based", True):
+        ClassDocumenter.add_directive_header = add_directive_header  # type: ignore[method-assign]

--- a/src/scanpydoc/release_notes.py
+++ b/src/scanpydoc/release_notes.py
@@ -138,6 +138,9 @@ class _BackendMyst(_Backend):
         from docutils.parsers.rst.directives.misc import Include
 
         srcfile, lineno = self.instance.get_source_info()
+        if srcfile is None or lineno is None:
+            msg = "Could not determine source info."
+            raise self.instance.error(msg)
         parent_dir = Path(srcfile).parent
 
         d = MockIncludeDirective(
@@ -167,8 +170,8 @@ class ReleaseNotes(SphinxDirective):
         dir_ = Path(self.arguments[0])
         # resolve relative dir
         if not dir_.is_absolute():
-            src_file = Path(self.get_source_info()[0])
-            if not src_file.is_file():
+            src_file = Path(s) if (s := self.get_source_info()[0]) else None
+            if not src_file or not src_file.is_file():
                 msg = f"Cannot find relative path to: {src_file}"
                 raise self.error(msg)
             dir_ = src_file.parent / self.arguments[0]

--- a/src/scanpydoc/release_notes.py
+++ b/src/scanpydoc/release_notes.py
@@ -138,7 +138,7 @@ class _BackendMyst(_Backend):
         from docutils.parsers.rst.directives.misc import Include
 
         srcfile, lineno = self.instance.get_source_info()
-        if srcfile is None or lineno is None:
+        if srcfile is None or lineno is None:  # pragma: no cover
             msg = "Could not determine source info."
             raise self.instance.error(msg)
         parent_dir = Path(srcfile).parent

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,7 @@ import pytest
 
 if TYPE_CHECKING:
     from types import ModuleType
-    from typing import Any
+    from typing import Any, NamedTuple
     from pathlib import Path
     from collections.abc import Callable, Generator
 
@@ -22,22 +22,39 @@ if TYPE_CHECKING:
 
     from scanpydoc.testing import MakeApp
 
+    class _AppParams(NamedTuple):
+        args: tuple[Any, ...]
+        kwargs: dict[str, Any]
+
 
 @pytest.fixture
-def make_app_setup(make_app: type[SphinxTestApp], tmp_path: Path) -> MakeApp:
+def make_app_setup(
+    tmp_path: Path, make_app: type[SphinxTestApp], app_params: _AppParams
+) -> MakeApp:
+    def get_builder(buildername: str = "html", **_: object) -> str:
+        return buildername  # make sure there are no conflicts
+
     def make_app_setup(
-        builder: str = "html",
+        buildername: str | None = None,
         /,
         *,
         exception_on_warning: bool = False,
         **conf: Any,  # noqa: ANN401
     ) -> SphinxTestApp:
         (tmp_path / "conf.py").write_text("")
-        conf.setdefault("suppress_warnings", []).append("app.add_node")
+
+        if buildername is None:
+            buildername = get_builder(*app_params.args, **app_params.kwargs)
+            app_params.kwargs.pop("buildername", None)
+
+        confoverrides = app_params.kwargs.get("confoverrides", {}).copy()
+        confoverrides.update(conf)
+        confoverrides.setdefault("suppress_warnings", []).append("app.add_node")
+
         return make_app(
-            buildername=builder,
+            buildername=buildername,
             srcdir=tmp_path,
-            confoverrides=conf,
+            confoverrides=confoverrides,
             warningiserror=exception_on_warning,
             exception_on_warning=exception_on_warning,
         )

--- a/tests/test_elegant_typehints.py
+++ b/tests/test_elegant_typehints.py
@@ -378,7 +378,7 @@ def test_autodoc(
     """Test that autodoc respects qualname_overrides after patching it."""
     Path(app.srcdir, "index.rst").write_text(
         f"""\
-.. {direc}:: test.{sub}
+.. {direc}:: testmod.{sub}
    :show-inheritance:
 """,
     )


### PR DESCRIPTION
deals with the changes in tests and docs.

scanpydoc doesn’t actually need a release to be compatible, the code changes just make it a bit more robust