### PR TITLE
fix: stop breaking Sphinx options cache

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 ]
 requires-python = '>=3.12'
 dependencies = [
-    'sphinx>=7.0',
+    'sphinx>=8.2',
 ]
 
 [project.optional-dependencies]

--- a/src/scanpydoc/elegant_typehints/__init__.py
+++ b/src/scanpydoc/elegant_typehints/__init__.py
@@ -120,8 +120,8 @@ def _init_vars(_app: Sphinx, config: Config) -> None:
 @dataclass
 class PickleableCallable:
     func: Callable[..., Any]
-    args: Sequence[Any] = field(default=())
-    kwargs: Mapping[str, Any] = field(default=MappingProxyType({}))
+    args: Sequence[Any] = field(default=(), compare=False)
+    kwargs: Mapping[str, Any] = field(default=MappingProxyType({}), compare=False)
 
     __call__ = property(lambda self: partial(self.func, **self.kwargs))
 


### PR DESCRIPTION
This PR allows comparing an unpickled typehints_formatter as equal to another