### PR TITLE
fix: use `/blob/` in GitHub URLs instead of `/tree/`

### DIFF
--- a/src/scanpydoc/rtd_github_links/__init__.py
+++ b/src/scanpydoc/rtd_github_links/__init__.py
@@ -106,11 +106,11 @@ def _init_vars(_app: Sphinx, config: Config) -> None:  # pragma: no cover
 def _infer_vars(config: Config) -> tuple[str, PurePosixPath]:
     _check_html_config(config)
     try:
-        github_base_url = "https://github.com/{github_user}/{github_repo}/tree/{github_version}".format_map(
+        github_base_url = "https://github.com/{github_user}/{github_repo}/blob/{github_version}".format_map(
             config.html_context,
         )
     except (AttributeError, KeyError):
-        github_base_url = "{repository_url}/tree/{repository_branch}".format_map(
+        github_base_url = "{repository_url}/blob/{repository_branch}".format_map(
             config.html_theme_options,
         )
     rtd_links_prefix = PurePosixPath(config.rtd_links_prefix)

--- a/tests/test_rtd_github_links.py
+++ b/tests/test_rtd_github_links.py
@@ -87,7 +87,7 @@ def test_infer_vars(config: Config, opt_name: str, opt: dict[str, str]) -> None:
     config.add(opt_name, {}, rebuild="", types=[dict])
     config[opt_name] = opt
     gbu, rlp = _infer_vars(config)
-    assert gbu == "https://github.com/scverse/scanpydoc/tree/test-branch"
+    assert gbu == "https://github.com/scverse/scanpydoc/blob/test-branch"
     assert rlp
 
 


### PR DESCRIPTION
GitHub doesn’t always seem to redirect here …