### PR TITLE
fix: simplify s-a-t usage

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,4 +11,6 @@
             "source.organizeImports": "explicit",
         },
     },
+    "python-envs.defaultEnvManager": "pypa.hatch:hatch",
+    "python-envs.defaultPackageManager": "pypa.hatch:hatch",
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ doc = [
     'scanpydoc[typehints,myst,theme]',
     'sphinx',
 ]
-typehints = ['sphinx-autodoc-typehints>=1.15.2']
+typehints = ['sphinx-autodoc-typehints>=3.8.0']
 theme = ['sphinx-book-theme>=1.1.0']
 myst = ['myst-parser']
 

--- a/src/scanpydoc/elegant_typehints/_formatting.py
+++ b/src/scanpydoc/elegant_typehints/_formatting.py
@@ -1,11 +1,8 @@
 from __future__ import annotations
 
 from types import GenericAlias
-from typing import TYPE_CHECKING, TypeAliasType, cast, get_args, get_origin
+from typing import TYPE_CHECKING, cast, get_args, get_origin
 
-from docutils import nodes
-from sphinx.addnodes import pending_xref
-from sphinx.ext.intersphinx import resolve_reference_detect_inventory
 from sphinx_autodoc_typehints import format_annotation
 
 from scanpydoc import elegant_typehints
@@ -39,10 +36,7 @@ def typehints_formatter(
     -------
     reStructuredText describing the type
     """
-    if isinstance(annotation, TypeAliasType):
-        if ref := _link_or_expand_alias(annotation, app=app):
-            return ref
-        return format_annotation(annotation.__value__, config)
+    del app
 
     if isinstance(annotation, type) and annotation.__module__ == "builtins":
         return None
@@ -60,30 +54,6 @@ def typehints_formatter(
         return _fmt_type(annotation, args, config)
 
     return None  # pragma: no cover
-
-
-def _link_or_expand_alias(
-    annotation: TypeAliasType, *, app: Sphinx | None
-) -> str | None:
-    """Eagerly try to resolve the reference and return it if it does."""
-    if app is None or "sphinx.ext.intersphinx" not in app.extensions:
-        return None
-    role, qualname = "py:type", f"{annotation.__module__}.{annotation.__name__}"
-    if override := elegant_typehints.qualname_overrides.get((role, qualname)):
-        role = override[0] or "py:type"
-        qualname = override[1]
-        return f":{role}:`{qualname}`"
-
-    from . import _last_resolve
-
-    domain, typ = role.split(":", 1)
-    xref = pending_xref(refdomain=domain, reftype=typ, reftarget=qualname)
-    contnode = nodes.TextElement()
-    if _last_resolve(
-        app, app.env, xref, contnode
-    ) or resolve_reference_detect_inventory(app.env, xref, contnode):
-        return f":{role}:`{qualname}`"
-    return None
 
 
 def _fmt_type(cls: type, args: Sequence[Any] | None, config: Config) -> str | None:

--- a/tests/test_elegant_typehints.py
+++ b/tests/test_elegant_typehints.py
@@ -28,7 +28,7 @@ from scanpydoc.elegant_typehints._formatting import typehints_formatter
 if TYPE_CHECKING:
     from io import StringIO
     from types import ModuleType
-    from typing import Literal, Protocol, NamedTuple
+    from typing import Protocol, NamedTuple
     from collections.abc import Generator
 
     from sphinx.application import Sphinx
@@ -147,42 +147,6 @@ def test_app(app: Sphinx) -> None:
 @pytest.mark.parametrize("annotation", [str, int | str], ids=["type", "union"])
 def test_default(app: Sphinx, annotation: object) -> None:
     assert typehints_formatter(annotation, app.config) is None
-
-
-@pytest.mark.parametrize("env", ["no_app", "app", "intersphinx"])
-def test_typealiastype_expand(
-    *, app: Sphinx, env: Literal["no_app", "app", "intersphinx"]
-) -> None:
-    app_arg = None if env == "no_app" else app
-    if env == "intersphinx":
-        app.setup_extension("sphinx.ext.intersphinx")
-    type Foo = int  # pyright: ignore[reportGeneralTypeIssues]
-    assert typehints_formatter(Foo, app.config, app=app_arg) == ":py:class:`int`"
-
-
-@pytest.mark.parametrize("override", [False, True], ids=["no_override", "override"])
-def test_typealiastype_link(
-    *, app: Sphinx, testmod: ModuleType, override: bool
-) -> None:
-    app.setup_extension("sphinx.ext.intersphinx")
-    if override:
-        docname = "foo.Bar"
-        qualname_overrides[None, "testmod.SomeAlias"] = ("py:type", docname)
-    else:
-        docname = "testmod.SomeAlias"
-
-    InventoryAdapter(app.env).main_inventory["py:type"] = {
-        docname: _InventoryItem(
-            project_name="TestProj",
-            project_version="1",
-            uri="https://x.com",
-            display_name=docname.split(".")[-1],
-        ),
-    }
-    assert (
-        typehints_formatter(testmod.SomeAlias, app.config, app=app)
-        == f":py:type:`{docname}`"
-    )
 
 
 def test_doc_ref(app: Sphinx) -> None:


### PR DESCRIPTION
our hack is now supported upstream: https://github.com/tox-dev/sphinx-autodoc-typehints/pull/626